### PR TITLE
Bugfix/182 focus not returned

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -111,7 +111,7 @@ function registerGlobalKeyboardShortcut(toggleAction: () => void, newHotKey: Glo
 }
 
 function showMainWindow() {
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    if (isMainWindowOpen()) {
         if (mainWindow.isVisible()) {
             mainWindow.focus();
         } else {
@@ -248,7 +248,7 @@ function updateConfig(updatedConfig: UserConfigOptions, needsIndexRefresh?: bool
 }
 
 function updateMainWindowSize(searchResultCount: number, appearanceOptions: AppearanceOptions, center?: boolean) {
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    if (isMainWindowOpen()) {
         mainWindow.setResizable(true);
         const windowHeight = searchResultCount > appearanceOptions.maxSearchResultsPerPage
             ? Math.round(getMaxWindowHeight(
@@ -356,7 +356,7 @@ function destroyTrayIcon() {
 }
 
 function onMainWindowMove() {
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    if (isMainWindowOpen()) {
         const currentPosition = mainWindow.getPosition();
         if (currentPosition.length === 2) {
             lastWindowPosition = {
@@ -432,14 +432,22 @@ function setKeyboardShortcuts() {
     }
 }
 
+function isMainWindowOpen() {
+  return !!(mainWindow && !mainWindow.isDestroyed());
+}
+
+function isSettingsWindowOpen() {
+    return !!(settingsWindow && !settingsWindow.isDestroyed());
+}
+
 function onLanguageChange(updatedConfig: UserConfigOptions) {
     translationSet = getTranslationSet(updatedConfig.generalOptions.language);
 
-    if (settingsWindow && !settingsWindow.isDestroyed()) {
+    if (isSettingsWindowOpen()) {
         settingsWindow.setTitle(translationSet.settings);
     }
 
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    if (isMainWindowOpen()) {
         mainWindow.webContents.send(IpcChannels.languageUpdated, translationSet);
     }
 
@@ -491,7 +499,7 @@ function updateSearchResults(results: SearchResultItem[], webcontents: WebConten
 }
 
 function noSearchResultsFound() {
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    if (isMainWindowOpen()) {
         updateMainWindowSize(1, config.appearanceOptions);
         const noResultFound = getErrorSearchResultItem(translationSet.generalErrorTitle, translationSet.generalErrorDescription);
         mainWindow.webContents.send(IpcChannels.searchResponse, [noResultFound]);
@@ -499,7 +507,7 @@ function noSearchResultsFound() {
 }
 
 function sendMessageToSettingsWindow(ipcChannel: IpcChannels, message: string) {
-    if (settingsWindow && !settingsWindow.isDestroyed()) {
+    if (isSettingsWindowOpen()) {
         settingsWindow.webContents.send(ipcChannel, message);
     }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -154,16 +154,30 @@ function onBlur() {
 }
 
 function hideMainWindow() {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send(IpcChannels.mainWindowHasBeenHidden);
+    if (!isMainWindowOpen()) {
+        return;
+    }
 
-        setTimeout(() => {
-            updateMainWindowSize(0, config.appearanceOptions);
-            if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(IpcChannels.mainWindowHasBeenHidden);
+
+    setTimeout(() => {
+        updateMainWindowSize(0, config.appearanceOptions);
+        if (isMainWindowOpen()) {
+            if (isMacOs(platform())) {
+                // As app.hide() hides all app windows, invoke it only when the settings are not open
+                if (!isSettingsWindowOpen()) {
+                    app.hide();
+                }
+
+                mainWindow.hide();
+            } else if (isWindows(platform())) {
+                mainWindow.minimize();
+                mainWindow.hide();
+            } else {
                 mainWindow.hide();
             }
-        }, 25);
-    }
+        }
+    }, 25);
 }
 
 function toggleMainWindow() {


### PR DESCRIPTION
This pull request is an improvement over [PR 180](https://github.com/oliverschwendener/ueli/pull/180) where there were issues regarding the settings window. Thus is was not merged.

On macOS, where `app.hide()` is necessary to return focus to the previous window, a check is made before invocation to skip hiding the app if the settings window is open. As then only the main window is hidden, focus remains with the same application (ueli) and falls back to a previously focused element, if any.

I refactored out the checks if the windows are open to separate functions to easier see what's going on. Also, I added a small comment regarding the special behavior.

Tested on macOS and Windows 10, with settings open and closed, and "Hide window when focus is lost" both on and off.

Also, the source and destination of the PR are `dev`.

@oliverschwendener Now I wonder if you find further issues :-)

Fixes: #182