### PR TITLE
Show suggestion for web search plugins

### DIFF
--- a/src/common/config/websearch-options.ts
+++ b/src/common/config/websearch-options.ts
@@ -27,6 +27,7 @@ export const defaultWebSearchOptions: WebSearchOptions = {
             name: "DuckDuckGo",
             prefix: "d?",
             priority: 1,
+            suggestionUrl: "https://ac.duckduckgo.com/ac/?q={{query}}&type=list",
             url: "https://duckduckgo.com/?q={{query}}",
         },
         {
@@ -46,6 +47,7 @@ export const defaultWebSearchOptions: WebSearchOptions = {
             name: "Google",
             prefix: "g?",
             priority: 2,
+            suggestionUrl: "https://www.google.com/complete/search?client=opera&q={{query}}",
             url: "https://google.com/search?q={{query}}",
         },
         {
@@ -69,6 +71,7 @@ export const defaultWebSearchOptions: WebSearchOptions = {
             name: "Google Images",
             prefix: "gi?",
             priority: 3,
+            suggestionUrl: "https://www.google.com/complete/search?ds=i&output=firefox&q={{query}}",
             url: "https://www.google.com/search?tbm=isch&q={{query}}",
         },
         {
@@ -85,6 +88,7 @@ export const defaultWebSearchOptions: WebSearchOptions = {
             name: "Wikipedia",
             prefix: "w?",
             priority: 4,
+            suggestionUrl: "https://en.wikipedia.org/w/api.php?action=opensearch&search={{query}}",
             url: "https://en.wikipedia.org/wiki/{{query}}",
         },
         {
@@ -102,6 +106,7 @@ export const defaultWebSearchOptions: WebSearchOptions = {
             name: "YouTube",
             prefix: "yt?",
             priority: 5,
+            suggestionUrl: "https://www.google.com/complete/search?ds=yt&output=firefox&q={{query}}",
             url: "https://www.youtube.com/results?search_query={{query}}",
         },
         {
@@ -114,6 +119,7 @@ export const defaultWebSearchOptions: WebSearchOptions = {
             name: "Bing",
             prefix: "b?",
             priority: 6,
+            suggestionUrl: "https://www.bing.com/osjson.aspx?query={{query}}",
             url: "https://www.bing.com/search?q={{query}}",
         },
     ],

--- a/src/common/translation/english-translation-set.ts
+++ b/src/common/translation/english-translation-set.ts
@@ -215,6 +215,7 @@ export const englishTranslationSet: TranslationSet = {
     websearchName: "Name",
     websearchPrefix: "Prefix",
     websearchUrl: "URL",
+    websearchSuggestionUrl: "Suggestion URL",
     websearchIcon: "Icon",
     websearchPriority: "Priority",
     websearchIsFallback: "Fallback",

--- a/src/common/translation/german-translation-set.ts
+++ b/src/common/translation/german-translation-set.ts
@@ -215,6 +215,7 @@ export const germanTranslationSet: TranslationSet = {
     websearchName: "Name",
     websearchPrefix: "Präfix",
     websearchUrl: "URL",
+    websearchSuggestionUrl: "Vorschlag URL",
     websearchIcon: "Icon",
     websearchPriority: "Priorität",
     websearchIsFallback: "Fallback",

--- a/src/common/translation/russian-translation-set.ts
+++ b/src/common/translation/russian-translation-set.ts
@@ -215,6 +215,7 @@ export const russianTranslationSet: TranslationSet = {
     websearchName: "Имя",
     websearchPrefix: "Префикс",
     websearchUrl: "URL",
+    websearchSuggestionUrl: "Предложение URL",
     websearchIcon: "Иконка",
     websearchPriority: "Приоритет",
     websearchIsFallback: "Запасная",

--- a/src/common/translation/translation-set.ts
+++ b/src/common/translation/translation-set.ts
@@ -212,6 +212,7 @@ export interface TranslationSet {
     websearchName: string;
     websearchPrefix: string;
     websearchUrl: string;
+    websearchSuggestionUrl: string;
     websearchIcon: string;
     websearchPriority: string;
     websearchIsFallback: string;

--- a/src/main/plugins/websearch-plugin/web-search-engine.ts
+++ b/src/main/plugins/websearch-plugin/web-search-engine.ts
@@ -8,4 +8,5 @@ export interface WebSearchEngine {
     priority: number;
     isFallback: boolean;
     encodeSearchTerm: boolean;
+    suggestionUrl: string;
 }

--- a/src/main/plugins/websearch-plugin/web-search-helpers.ts
+++ b/src/main/plugins/websearch-plugin/web-search-helpers.ts
@@ -12,6 +12,7 @@ export const defaultNewWebSearchEngine: WebSearchEngine = {
     name: "",
     prefix: "",
     priority: 0,
+    suggestionUrl: "",
     url: "",
 };
 

--- a/src/main/plugins/websearch-plugin/websearch-plugin.ts
+++ b/src/main/plugins/websearch-plugin/websearch-plugin.ts
@@ -43,13 +43,13 @@ export class WebSearchPlugin implements ExecutionPlugin {
                     return 0;
                 });
 
-            webSearchEngines.forEach((webSearchEngine, index) => {
+            webSearchEngines.forEach((webSearchEngine) => {
                 searchResults.push({
-                    description: this.buildDescription(webSearchEngines[index], userInput),
-                    executionArgument: this.buildExecutionArgument(webSearchEngines[index], userInput),
+                    description: this.buildDescription(webSearchEngine, userInput),
+                    executionArgument: this.buildExecutionArgument(webSearchEngine, userInput),
                     hideMainWindowAfterExecution: true,
-                    icon: isValidIcon(webSearchEngines[index].icon) ? webSearchEngines[index].icon : defaultWebSearchIcon,
-                    name: userInput.replace(webSearchEngines[index].prefix, ""),
+                    icon: isValidIcon(webSearchEngine.icon) ? webSearchEngine.icon : defaultWebSearchIcon,
+                    name: userInput.replace(webSearchEngine.prefix, ""),
                     originPluginType: this.pluginType,
                     searchable: [],
                 });
@@ -77,7 +77,7 @@ export class WebSearchPlugin implements ExecutionPlugin {
                         const suggestionsResults: SearchResultItem[] = [];
                         const suggestionsData = response.data[1];
 
-                        suggestionsData.some((suggestion: string) => {
+                        suggestionsData.some((suggestion: string,index:number) => {
                             suggestionsResults.push({
                                 description: this.buildDescription(webSearchEngine, suggestion),
                                 executionArgument: this.buildExecutionArgument(webSearchEngine, suggestion),
@@ -88,7 +88,7 @@ export class WebSearchPlugin implements ExecutionPlugin {
                                 searchable: [],
                             })
 
-                            return suggestion === suggestionsData[7];
+                            return index === 7;
                         })
                         resolve(suggestionsResults)
                     }))

--- a/src/main/production/production-search-engine.ts
+++ b/src/main/production/production-search-engine.ts
@@ -127,7 +127,7 @@ export function getProductionSearchEngine(config: UserConfigOptions, translation
         ),
     ];
 
-    const webSearchPlugin = new WebSearchPlugin(config.websearchOptions, translationSet, urlExecutor);
+    const webSearchPlugin = new WebSearchPlugin(config.websearchOptions, translationSet, logger, urlExecutor);
 
     const executionPlugins: ExecutionPlugin[] = [
         webSearchPlugin,

--- a/src/renderer/settings/modals/websearch-editing-modal-component.ts
+++ b/src/renderer/settings/modals/websearch-editing-modal-component.ts
@@ -60,6 +60,10 @@ export const websearchEditingModal = Vue.extend({
             const translations: TranslationSet = this.translations;
             return `${translations.forExample}: "https://google.com/search?q={{query}}"`;
         },
+        getSuggestionUrlPlaceholder(): string {
+            const translations: TranslationSet = this.translations;
+            return `${translations.forExample}: https://www.google.com/complete/search?client=chrome&q={{query}}`;
+        },
     },
     mounted() {
         vueEventDispatcher.$on(VueEventChannels.openWebSearchEditingModal, (websearchEngine: WebSearchEngine, editMode: ModalEditMode, saveIndex?: number) => {
@@ -107,6 +111,15 @@ export const websearchEditingModal = Vue.extend({
                         </label>
                         <div class="control is-expanded">
                             <input class="input" type="url" v-model="websearchEngine.url" :placeholder="getUrlPlaceholder()">
+                        </div>
+                    </div>
+
+                    <div class="field">
+                        <label class="label">
+                            {{ translations.websearchSuggestionUrl }}
+                        </label>
+                        <div class="control is-expanded">
+                            <input class="input" type="url" v-model="websearchEngine.suggestionUrl" :placeholder="getSuggestionUrlPlaceholder()">
                         </div>
                     </div>
 

--- a/src/renderer/settings/websearch-settings-component.ts
+++ b/src/renderer/settings/websearch-settings-component.ts
@@ -115,6 +115,7 @@ export const webSearchSettingsComponent = Vue.extend({
                                 <th>{{ translations.websearchName }}</th>
                                 <th>{{ translations.websearchPrefix }}</th>
                                 <th>{{ translations.websearchUrl }}</th>
+                                <th>{{ translations.websearchSuggestionUrl }}</th>
                                 <th class="has-text-centered">{{ translations.websearchIcon }}</th>
                                 <th class="has-text-centered">{{ translations.websearchPriority }}</th>
                                 <th class="has-text-centered">{{ translations.websearchIsFallback }}</th>
@@ -128,6 +129,7 @@ export const webSearchSettingsComponent = Vue.extend({
                                 <td>{{ websearchEngine.name }}</td>
                                 <td class="font-mono">{{ websearchEngine.prefix }}</td>
                                 <td>{{ websearchEngine.url }}</td>
+                                <td>{{ websearchEngine.suggestionUrl }}</td>
                                 <td class="has-text-centered"><icon :icon="websearchEngine.icon" :defaulticon="defaultWebSearchIcon"></icon></td>
                                 <td class="has-text-centered">{{ websearchEngine.priority }}</td>
                                 <td class="has-text-centered"><i v-if="websearchEngine.isFallback" class="fas fa-check"></i></td>


### PR DESCRIPTION
Closes #265. 
This PR:
1. adds search suggestions to web search plugin(for now i limited it to 8 suggestion cause frankly I think that's enough).
2. adds default values for suggestion url for all default engines.
3. adds input field and preview for suggestions url. ( Translations for Russian and German are translated by google so they might not be the best. )

**Note: users will have to reset the plugin settings to default first.**

<s>This is not perfect actually, i tried to make it work if a multiple search engines has the same prefix it would get suggestion for every webSearchEngine but that comes with a draw back, say i have two search engines, "duckduckgo and google"  with the same prefix but google's priority is higher, now if google's axios call is successful and duckduck go is not, we get suggestions for google only and  that's fine but if it was the other way around and  google fails first, then duckduckgo's respones won't even get handled as the execution goes straight to the `.catch()` block after the first error and never goes back to the `.then()` block.

The problem in my opinion is that users can set the same prefix for multiple webSearchEngines and even plugins, I think it would be better to have some sorta of a prefix validation that doesn't allow the user to set the same prefix for multiple webSearchEngines and also plugins. That would solve the problem.</s>