### PR TITLE
Fix Catalina missing system apps

### DIFF
--- a/src/common/config/application-search-options.ts
+++ b/src/common/config/application-search-options.ts
@@ -27,6 +27,7 @@ const macOsApplicationSearchOptions: ApplicationSearchOptions = {
         "/Applications",
         "/System/Library/CoreServices",
         `${homedir()}/Applications`,
+        "/System/Applications",
     ],
     enabled: true,
     showFullFilePath: false,


### PR DESCRIPTION
Prior to this change, while searching to find system apps there were no hits.  Catalina seems to have the applications under `System/Applications`
eg Calendar.app Mail.app

This change adds the `System/Applications` folder to the default application search folders

Issue: oliverschwendener#278