### PR TITLE
add ctrl + number to quickly open search item

### DIFF
--- a/src/renderer/search-results-component.ts
+++ b/src/renderer/search-results-component.ts
@@ -137,6 +137,16 @@ export const searchResultsComponent = Vue.extend({
                 }
             }
         });
+        vueEventDispatcher.$on(VueEventChannels.ctrlNumberExecute, (userInput: string, index: number, privileged: boolean, userConfirmed?: boolean) => {
+            const chosenItem = this.searchResults[index];
+            if (chosenItem && chosenItem.originPluginType !== PluginType.None) {
+                if (chosenItem.needsUserConfirmationBeforeExecution && !userConfirmed) {
+                    vueEventDispatcher.$emit(VueEventChannels.userConfirmationRequested);
+                } else {
+                    vueEventDispatcher.$emit(VueEventChannels.handleExecution, userInput, chosenItem, privileged);
+                }
+            }
+        });
         vueEventDispatcher.$on(VueEventChannels.openSearchResultLocationKeyPress, () => {
             const activeItem: SearchResultItemViewModel = this.getActiveSearchResultItem();
             if (activeItem && activeItem.supportsOpenLocation && activeItem.originPluginType !== PluginType.None) {

--- a/src/renderer/user-input-component.ts
+++ b/src/renderer/user-input-component.ts
@@ -62,6 +62,15 @@ export const userInputComponent = Vue.extend({
             if (event.key.toLowerCase() === "o" && (event.ctrlKey || event.metaKey)) {
                 vueEventDispatcher.$emit(VueEventChannels.openSearchResultLocationKeyPress);
             }
+            const keyIntger = parseInt(event.key, 10);
+
+            if (event.ctrlKey && !isNaN(keyIntger) && (keyIntger > 0 && keyIntger <= 9)) {
+                event.preventDefault();
+                const userConfirmed: boolean = this.userConfirmationDialogVisible;
+                const privileged: boolean = event.shiftKey;
+                vueEventDispatcher.$emit(VueEventChannels.ctrlNumberExecute, this.userInput, keyIntger - 1, privileged, userConfirmed);
+            }
+
         },
         resetUserInput(): void {
             this.userInput = "";

--- a/src/renderer/vue-event-channels.ts
+++ b/src/renderer/vue-event-channels.ts
@@ -49,4 +49,5 @@ export enum VueEventChannels {
     refreshIndexesStarted = "refresh-indexes-started",
     refreshIndexesFinished = "refresh-indexes-finished",
     executionFinished = "execution-finished",
+    ctrlNumberExecute = "ctrl+number-execute",
 }


### PR DESCRIPTION
This PR adds a feature I requested here #305 to add "ctrl + number(1-9)" for fast access to search items. 

I wanted to make the numbers of the search item appear when "ctrl" is pressed but I can't find a way to do so since it's dependent on user's config, any thoughts ? 