### PR TITLE
Fix search results scrolling

### DIFF
--- a/src/renderer/user-input-component.ts
+++ b/src/renderer/user-input-component.ts
@@ -180,6 +180,7 @@ export const userInputComponent = Vue.extend({
             <input
                 :disabled="userInputDisabled"
                 ref="userInput"
+                id="user-input"
                 class="user-input__input"
                 type="text"
                 v-model="userInput"


### PR DESCRIPTION
The removed id of the user input control (commit 5a4fbd7c7d) broke scrolling on arrow-down/up in search results (search-results-component scrollIntoView() uses the id to get the element).