### PR TITLE
ignore Windows application searcher errors

### DIFF
--- a/src/main/executors/application-searcher.ts
+++ b/src/main/executors/application-searcher.ts
@@ -9,8 +9,9 @@ export function searchWindowsApplications(applicationSearchOptions: ApplicationS
         }
 
         const utf8Encoding = "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8";
+        const ignoreErrors = "$ErrorActionPreference = 'SilentlyContinue'";
         const extensionFilter = applicationSearchOptions.applicationFileExtensions.map((e) => `*${e}`).join(", ");
-        const getChildItem = `${utf8Encoding}; Get-ChildItem -Path $_ -include ${extensionFilter} -Recurse -File | % { $_.FullName }`;
+        const getChildItem = `${utf8Encoding}; ${ignoreErrors}; Get-ChildItem -Path $_ -include ${extensionFilter} -Recurse -File | % { $_.FullName }`;
         const folders = applicationSearchOptions.applicationFolders.map((applicationFolder) => `'${applicationFolder}'`).join(",");
         const powershellScript = `${folders} | %{ ${getChildItem} }`;
 

--- a/src/main/executors/application-searcher.ts
+++ b/src/main/executors/application-searcher.ts
@@ -1,8 +1,9 @@
 import { normalize } from "path";
 import { ApplicationSearchOptions } from "../../common/config/application-search-options";
 import { executeCommandWithOutput } from "./command-executor";
+import { Logger } from "../../common/logger/logger";
 
-export function searchWindowsApplications(applicationSearchOptions: ApplicationSearchOptions): Promise<string[]> {
+export function searchWindowsApplications(applicationSearchOptions: ApplicationSearchOptions, logger: Logger): Promise<string[]> {
     return new Promise((resolve, reject) => {
         if (applicationSearchOptions.applicationFolders.length === 0 || applicationSearchOptions.applicationFileExtensions.length === 0) {
             resolve([]);
@@ -10,19 +11,21 @@ export function searchWindowsApplications(applicationSearchOptions: ApplicationS
 
         const utf8Encoding = "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8";
         const ignoreErrors = "$ErrorActionPreference = 'SilentlyContinue'";
-        const extensionFilter = applicationSearchOptions.applicationFileExtensions.map((e) => `*${e}`).join(", ");
-        const getChildItem = `${utf8Encoding}; ${ignoreErrors}; Get-ChildItem -Path $_ -include ${extensionFilter} -Recurse -File | % { $_.FullName }`;
+        const createApplicationsArray = "$applications = New-Object Collections.Generic.List[String]"
         const folders = applicationSearchOptions.applicationFolders.map((applicationFolder) => `'${applicationFolder}'`).join(",");
-        const powershellScript = `${folders} | %{ ${getChildItem} }`;
-
-        executeCommandWithOutput(`powershell -Command "& { ${powershellScript} }"`)
-            .then((data) => {
-                const filePaths = data
-                    .split("\n")
-                    .map((f) => normalize(f).trim())
-                    .filter((f) => f.length > 1);
-
-                resolve(filePaths);
+        const extensionFilter = applicationSearchOptions.applicationFileExtensions.map((e) => `*${e}`).join(", ");
+        const getChildItem = `Get-ChildItem -Path $_ -include ${extensionFilter} -Recurse -File | % { $applications.Add($_.FullName) }`;
+        const createResult = `$result = (@{ errors = @($error | ForEach-Object { $_.Exception.Message }); applications = $applications } | ConvertTo-Json)`;
+        const printResult = "Write-Host $result";
+        const powershellScript = `${utf8Encoding}; ${ignoreErrors}; ${createApplicationsArray}; ${folders} | %{ ${getChildItem} }; ${createResult}; ${printResult};`;
+        const command = `powershell -Command "& { ${powershellScript} }"`;
+        executeCommandWithOutput(command)
+            .then((resultOutput: string) => {
+                const result : { errors: string[], applications: string[] } = JSON.parse(resultOutput);
+                if (result.errors && result.errors.length > 0) {
+                    logger.error('Errors occurred while searching for applications:\n' + result.errors.join("\n"));
+                }
+                resolve(result.applications);
             })
             .catch((err) => reject(err));
     });

--- a/src/main/plugins/application-search-plugin/production-application-repository.ts
+++ b/src/main/plugins/application-search-plugin/production-application-repository.ts
@@ -6,24 +6,28 @@ import { Icon } from "../../../common/icon/icon";
 import { ApplicationIconService } from "./application-icon-service";
 import { getApplicationIconFilePath } from "./application-icon-helpers";
 import { IconType } from "../../../common/icon/icon-type";
+import { Logger } from "../../../common/logger/logger";
 
 export class ProductionApplicationRepository implements ApplicationRepository {
     private applications: Application[];
     private readonly defaultAppIcon: Icon;
     private readonly appIconService: ApplicationIconService;
-    private readonly searchApplications: (options: ApplicationSearchOptions) => Promise<string[]>;
+    private readonly searchApplications: (options: ApplicationSearchOptions, logger: Logger) => Promise<string[]>;
     private config: ApplicationSearchOptions;
+    private readonly logger: Logger;
 
     constructor(
         config: ApplicationSearchOptions,
         defaultAppIcon: Icon,
         appIconService: ApplicationIconService,
-        searchApplications: (options: ApplicationSearchOptions) => Promise<string[]>,
+        searchApplications: (options: ApplicationSearchOptions, logger: Logger) => Promise<string[]>,
+        logger: Logger,
     ) {
         this.config = config;
         this.defaultAppIcon = defaultAppIcon;
         this.appIconService = appIconService,
         this.searchApplications = searchApplications;
+        this.logger = logger;
         this.applications = [];
     }
 
@@ -33,7 +37,7 @@ export class ProductionApplicationRepository implements ApplicationRepository {
 
     public refreshIndex(): Promise<void> {
         return new Promise((resolve, reject) => {
-            this.searchApplications(this.config)
+            this.searchApplications(this.config, this.logger)
                 .then((filePaths) => {
                     this.applications = filePaths.map((filePath) => this.createApplicationFromFilePath(filePath));
 

--- a/src/main/production/production-search-engine.ts
+++ b/src/main/production/production-search-engine.ts
@@ -92,6 +92,7 @@ export function getProductionSearchEngine(config: UserConfigOptions, translation
                     logger,
                 ),
                 applicationSearcher,
+                logger,
             ),
             filePathExecutor,
             filePathLocationExecutor,


### PR DESCRIPTION
The application searcher scans directories defined by the user. These directories can contain files that cannot be accessed and the directories could not exist anymore. Currently this causes the application searcher to throw an error so that no applications are indexed at all. I think we can just ignore all errors.