### PR TITLE
Add event emitter to update current results

### DIFF
--- a/src/common/ipc-channels.ts
+++ b/src/common/ipc-channels.ts
@@ -36,4 +36,5 @@ export enum IpcChannels {
     checkForUpdate = " check-for-update",
     checkForUpdateResponse = "check-for-update-response",
     downloadUpdate = "download-update",
+    updateCurrentResults = "update-current-results"
 }

--- a/src/main/helpers/node-event-emitter.ts
+++ b/src/main/helpers/node-event-emitter.ts
@@ -1,0 +1,3 @@
+import { EventEmitter } from "events"
+
+export const nodeEmitter = new EventEmitter();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -34,6 +34,7 @@ import { deepCopy } from "../common/helpers/object-helpers";
 import { PluginType } from "./plugin-type";
 import { getRescanIntervalInMilliseconds } from "./helpers/rescan-interval-helpers";
 import { openUrlInBrowser } from "./executors/url-executor";
+import { nodeEmitter } from "./helpers/node-event-emitter";
 
 if (!FileHelpers.fileExistsSync(ueliTempFolder)) {
     FileHelpers.createFolderSync(ueliTempFolder);
@@ -603,6 +604,10 @@ function registerAllIpcListeners() {
                 noSearchResultsFound();
             });
     });
+
+    nodeEmitter.on(IpcChannels.updateCurrentResults, (searchResults) => {
+        updateSearchResults(searchResults, mainWindow.webContents)
+    })
 
     ipcMain.on(IpcChannels.favoritesRequested, (event: Electron.IpcMainEvent) => {
         searchEngine.getFavorites()


### PR DESCRIPTION
This PR is gonna solve my other PR #283.
Basically I just created an event emitter and listen to its events in the main process, so whenever a plugin needs to update the results, we can just import the emitter and emit the event. 