### PR TITLE
Fixes #361 : Results Number mess up icon size

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -232,7 +232,7 @@ body {
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
-    max-width: calc(100% - var(--search-results--item-icon-size));  
+    max-width: calc(100% - var(--search-results--item-icon-size) * 2);
 }
 
 .search-results__item-number-container {


### PR DESCRIPTION
I fixed the bug #361 but I added some modifications:
1- I moved the numbers from right to left next to the icons.
2- Styled the numbers and added a vue transition to them. 

![Annotation 2020-05-16 155217](https://user-images.githubusercontent.com/48618675/82123268-bf634a80-9798-11ea-8cf7-cfe906d28f70.png)


These two changes would play nicely with my other PR #351 if it got merged. 