### PR TITLE
filter out duplicates from input history manager

### DIFF
--- a/src/main/user-input-history-manager.test.ts
+++ b/src/main/user-input-history-manager.test.ts
@@ -15,6 +15,26 @@ describe(TestableUserInputHistoryManager.name, (): void => {
             expect(actual[0]).toBe(userInput);
             expect(manager.getIndex()).toBe(1);
         });
+
+        it("should only add an item if it's not the same as the previous", (): void => {
+
+            const manager = new TestableUserInputHistoryManager();
+
+            const userInput1 = "test1";
+            const userInput2 = "test2";
+
+            manager.addItem(userInput1);
+            manager.addItem(userInput1);
+            manager.addItem(userInput2);
+
+            const actual = manager.getHistory();
+
+            expect(actual.length).toBe(2);
+            expect(actual[0]).toBe(userInput1);
+            expect(actual[1]).toBe(userInput2);
+            expect(manager.getIndex()).toBe(2);
+
+        });
     });
 
     describe("getPrevious", (): void => {

--- a/src/main/user-input-history-manager.ts
+++ b/src/main/user-input-history-manager.ts
@@ -8,7 +8,9 @@ export class UserInputHistoryManager {
     }
 
     public addItem(userInput: string): void {
-        this.history.push(userInput);
+        if (this.history[this.history.length - 1] !== userInput) {
+            this.history.push(userInput);
+        }
         this.index = this.history.length;
     }
 

--- a/src/main/user-input-history-manager.ts
+++ b/src/main/user-input-history-manager.ts
@@ -8,7 +8,11 @@ export class UserInputHistoryManager {
     }
 
     public addItem(userInput: string): void {
-        if (this.history[this.history.length - 1] !== userInput) {
+        if (this.history.length > 0) {
+            if (this.history[this.history.length - 1] !== userInput) {
+                this.history.push(userInput);
+            }
+        } else {
             this.history.push(userInput);
         }
         this.index = this.history.length;


### PR DESCRIPTION
Having duplicates in userInput history manager is inconvenient, A lot of times I open an application like 5 times in a row and It makes no sense to cycle through the same 5 input history.