### PR TITLE
Fix UWP plugin index refresh

### DIFF
--- a/src/main/plugins/uwp-plugin/uwp-apps-retriever.ts
+++ b/src/main/plugins/uwp-plugin/uwp-apps-retriever.ts
@@ -32,7 +32,7 @@ filter ArrayToHash
 }
 
 [string[]]$alreadyKnownAppIds = %alreadyKnownAppIds%;
-$alreadyKnownAppIdsSet = New-Object System.Collections.Generic.HashSet[string] ($alreadyKnownAppIds);
+$alreadyKnownAppIdsSet = New-Object System.Collections.Generic.HashSet[string] (,$alreadyKnownAppIds);
 
 $currentStartApps = Get-StartApps | Where-Object { $_.AppID.Contains("!") };
 $currentStartAppIds = $currentStartApps | Select-Object -ExpandProperty AppID;


### PR DESCRIPTION
This fixes a bug in the UWP apps retriever that prevented newly installed apps from being detected when index was refreshed.