### PR TITLE
EverythingSearcher should use UTF8 encoding

### DIFF
--- a/src/main/plugins/everything-plugin/everything-searcher.ts
+++ b/src/main/plugins/everything-plugin/everything-searcher.ts
@@ -14,7 +14,8 @@ export class EverythingSearcher {
         pluginType: PluginType): Promise<SearchResultItem[]> {
         return new Promise((resolve, reject) => {
             const searchTerm = userInput.replace(everythingSearchOptions.prefix, "").trim();
-            const command = `"${everythingSearchOptions.pathToEs}" -max-results ${everythingSearchOptions.maxSearchResults} ${searchTerm}`;
+            const utf8Encoding = "cmd /c chcp 65001>nul &&";
+            const command = `${utf8Encoding} "${everythingSearchOptions.pathToEs}" -max-results ${everythingSearchOptions.maxSearchResults} ${searchTerm}`;
             exec(command, (everythingError, stdout, stderr) => {
                 if (everythingError) {
                     reject(everythingError);


### PR DESCRIPTION
This fixes the second issue from #401.