### PR TITLE
Fix opening control panel items with non-ASCII characters

### DIFF
--- a/src/main/plugins/control-panel-plugin/control-panel-plugin.ts
+++ b/src/main/plugins/control-panel-plugin/control-panel-plugin.ts
@@ -8,7 +8,7 @@ import { ControlPanelOptions } from "../../../common/config/control-panel-option
 import { ControlPanelItem } from "./control-panel-item";
 import { defaultControlPanelIcon } from "../../../common/icon/default-icons";
 import { ControlPanelItemsRetriever } from "./control-panel-items-retriever";
-import * as Powershell from "node-powershell";
+import { executeCommand } from "../../executors/command-executor";
 
 export class ControlPanelPlugin implements SearchPlugin {
     public pluginType = PluginType.ControlPanel;
@@ -26,12 +26,9 @@ export class ControlPanelPlugin implements SearchPlugin {
 
     public execute(searchResultItem: SearchResultItem, privileged: boolean): Promise<void> {
         return new Promise((resolve, reject) => {
-            const shell = new Powershell({});
-            shell.addCommand(`powershell -NonInteractive -NoProfile -Command "Show-ControlPanelItem -Name '${searchResultItem.executionArgument}'"`)
-                .then(() => shell.invoke())
+            executeCommand(`powershell -NonInteractive -NoProfile -Command "Show-ControlPanelItem -Name '${searchResultItem.executionArgument}'"`)
                 .then(() => resolve())
-                .catch((reason) => reject(reason))
-                .finally(() => shell.dispose());
+                .catch((reason) => reject(reason));
         });
     }
 


### PR DESCRIPTION
There are encoding issues with node-powershell when the script contains non-ASCII characters, like umlauts (äöü). That's why control panel items like `Geräte und Drucker` could not be opened. Using `executeCommand` fixes the issue.