### PR TITLE
fix results item overlay on transparent bg

### DIFF
--- a/src/renderer/search-results-component.ts
+++ b/src/renderer/search-results-component.ts
@@ -153,8 +153,7 @@ export const searchResultsComponent = Vue.extend({
     template: `
         <div class="search-results" :class="{ 'scroll-disabled' : isLoading }" :id="containerId">
             <div :id="searchResult.id" class="search-results__item" :class="{ 'active' : searchResult.active }" v-for="searchResult in searchResults">
-                <div class="search-results__item-icon-container">
-                    <div class="search-results__item-icon-overlay" :class="{ 'active' : searchResult.active }"></div>
+                <div class="search-results__item-icon-container" :class="{ 'active' : searchResult.active }">
                     <div class="search-results__item-icon" v-html="getIcon(searchResult.icon, searchResult.active)"></div>
                 </div>
                 <div class="search-results__item-info-container">

--- a/styles/app.css
+++ b/styles/app.css
@@ -175,6 +175,10 @@ body {
     height: var(--search-results--item-icon-size);
     position: relative;
     flex-shrink: 0;
+    opacity: 0.75;
+}
+.search-results__item-icon-container.active{
+    opacity: 1;
 }
 
 .search-results__item-icon {
@@ -211,20 +215,6 @@ body {
     width: var(--search-results--item-icon-size);
     border-radius: 50%;
     box-shadow: 0 2px 10px rgba(0,0,0,0.25);
-}
-
-.search-results__item-icon-overlay {
-    background-color: var(--search-results--background-color);
-    opacity: 0.25;
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
-}
-
-.search-results__item-icon-overlay.active {
-    opacity: 0;
 }
 
 .search-results__item-info-container {


### PR DESCRIPTION
Fixes #418 
The overlay was causing this issue with transparent background 
![image](https://user-images.githubusercontent.com/48618675/83461586-64ed0e00-a469-11ea-9937-1ab7249b4f80.png)
so I removed it and decreased the opacity a little bit which kinda similar to the intended look I guess but doesn't cause issues with transparent background.
![image](https://user-images.githubusercontent.com/48618675/83461517-3f600480-a469-11ea-85b5-5576c06f5e66.png)
