### PR TITLE
 #429 thousand separator 

### DIFF
--- a/src/main/plugins/calculator-plugin/calculator-plugin.ts
+++ b/src/main/plugins/calculator-plugin/calculator-plugin.ts
@@ -31,7 +31,7 @@ export class CalculatorPlugin implements ExecutionPlugin {
                 executionArgument: result,
                 hideMainWindowAfterExecution: true,
                 icon: defaultCalculatorIcon,
-                name: `= ${result}`,
+                name: `= ${Intl.NumberFormat().format(Number(result))}`,
                 originPluginType: this.pluginType,
                 searchable: [],
             }]);

--- a/src/main/plugins/calculator-plugin/calculator.ts
+++ b/src/main/plugins/calculator-plugin/calculator.ts
@@ -11,9 +11,9 @@ export class Calculator {
         if (blackListInputs.find((b) => input === b) !== undefined) {
             return false;
         }
-        
+
         input = this.removeCommas(input);
-        
+
         let result;
         try {
             // Mathjs throws an error when input cannot be evaluated

--- a/src/main/plugins/calculator-plugin/calculator.ts
+++ b/src/main/plugins/calculator-plugin/calculator.ts
@@ -11,10 +11,11 @@ export class Calculator {
         if (blackListInputs.find((b) => input === b) !== undefined) {
             return false;
         }
-
+        
+        input = this.removeCommas(input);
+        
         let result;
         try {
-            input = this.removeCommas(input);
             // Mathjs throws an error when input cannot be evaluated
             result = mathjs.eval(input);
         } catch (e) {

--- a/src/main/plugins/calculator-plugin/calculator.ts
+++ b/src/main/plugins/calculator-plugin/calculator.ts
@@ -14,6 +14,7 @@ export class Calculator {
 
         let result;
         try {
+            input = this.removeCommas(input);
             // Mathjs throws an error when input cannot be evaluated
             result = mathjs.eval(input);
         } catch (e) {
@@ -30,6 +31,7 @@ export class Calculator {
     }
 
     public static calculate(input: string, precision: number): string {
+        input = this.removeCommas(input);
         precision = Number(precision);
         if (precision > 64 || precision < 0) {
             precision = 16;
@@ -47,5 +49,12 @@ export class Calculator {
         }
 
         return true;
+    }
+
+    private static removeCommas(input: string): string {
+        if (input.includes(",")) {
+            input = input.replace(/,/g, "");
+        }
+        return input;
     }
 }


### PR DESCRIPTION
Current implementation just removes all commas from input before doing calculations without affecting input. Could maybe check if number has correct thousands separator?

![preview1](https://i.imgur.com/MgOiAXy.png)
![preview2](https://i.imgur.com/N3VvsQx.png)