### PR TITLE
Ensure file-path executing brings file to foreground

### DIFF
--- a/src/main/executors/file-path-executor.ts
+++ b/src/main/executors/file-path-executor.ts
@@ -1,33 +1,17 @@
 import { executeCommand } from "./command-executor";
-import { shell } from "electron";
 
 export function executeFilePathWindows(filePath: string, privileged: boolean): Promise<void> {
-    return privileged
-        ? executeFilePathWindowsAsPrivileged(filePath)
-        : openFile(filePath);
+    const command: string = privileged ?
+        `powershell -Command "& {Start-Process -Verb runas '${filePath}'}"` :
+        `powershell -Command "& {Start-Process '${filePath}'}"`;
+
+    return executeCommand(command);
 }
 
 export function executeFilePathMacOs(filePath: string, privileged: boolean): Promise<void> {
-    return privileged
-        ? executeFilePathMacOsAsPrivileged(filePath)
-        : openFile(filePath);
-}
+    const command: string = privileged ?
+        `osascript -e 'do shell script "open \\"${filePath}\\"" with administrator privileges"'` :
+        `osascript -e 'do shell script "open \\"${filePath}\\""'`;
 
-function openFile(filePath: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-        const result = shell.openItem(filePath);
-        if (result) {
-            resolve();
-        } else {
-            reject(`Failed to open: ${filePath}`);
-        }
-    });
-}
-
-function executeFilePathWindowsAsPrivileged(filePath: string): Promise<void> {
-    return executeCommand(`powershell -Command "& {Start-Process -Verb runas '${filePath}'}"`);
-}
-
-function executeFilePathMacOsAsPrivileged(filePath: string): Promise<void> {
-    return executeCommand(`osascript -e 'do shell script "open \\"${filePath}\\"" with administrator privileges'`);
+    return executeCommand(command);
 }

--- a/src/main/executors/file-path-executor.ts
+++ b/src/main/executors/file-path-executor.ts
@@ -1,17 +1,33 @@
 import { executeCommand } from "./command-executor";
+import { shell } from "electron";
 
 export function executeFilePathWindows(filePath: string, privileged: boolean): Promise<void> {
-    const command: string = privileged ?
-        `powershell -Command "& {Start-Process -Verb runas '${filePath}'}"` :
-        `powershell -Command "& {Start-Process '${filePath}'}"`;
-
-    return executeCommand(command);
+    return privileged
+        ? executeFilePathWindowsAsPrivileged(filePath)
+        : openFile(filePath);
 }
 
 export function executeFilePathMacOs(filePath: string, privileged: boolean): Promise<void> {
-    const command: string = privileged ?
-        `osascript -e 'do shell script "open \\"${filePath}\\"" with administrator privileges"'` :
-        `osascript -e 'do shell script "open \\"${filePath}\\""'`;
+    return privileged
+        ? executeFilePathMacOsAsPrivileged(filePath)
+        : openFile(filePath);
+}
 
-    return executeCommand(command);
+function openFile(filePath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const result = shell.openItem(filePath);
+        if (result) {
+            resolve();
+        } else {
+            reject(`Failed to open: ${filePath}`);
+        }
+    });
+}
+
+function executeFilePathWindowsAsPrivileged(filePath: string): Promise<void> {
+    return executeCommand(`powershell -Command "& {Start-Process -Verb runas '${filePath}'}"`);
+}
+
+function executeFilePathMacOsAsPrivileged(filePath: string): Promise<void> {
+    return executeCommand(`osascript -e 'do shell script "open \\"${filePath}\\"" with administrator privileges'`);
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -644,7 +644,7 @@ function registerAllIpcListeners() {
 
     ipcMain.on(IpcChannels.openSearchResultLocation, (event: Electron.Event, searchResultItem: SearchResultItem) => {
         searchEngine.openLocation(searchResultItem)
-            .then(() => hideMainWindowWithReturnFocus(false))
+            .then(() => hideMainWindowWithReturnFocus(true))
             .catch((err) => {
                 logger.error(err);
                 noSearchResultsFound();


### PR DESCRIPTION
This PR changes the `file-path-executor` to always use Powershell/`osascript`, rather than using `shell.openItem` for non-privileged openings. This ensures that the executed file path is always brought to the foreground.

For reasons I don't fully understand, certain application types are not brought to the foreground when opened with `ueli`. For example, MacOS preference panes open when launched with `ueli`, but the current application retains focus and so they appear to open in the background. Another example is Firefox, which has the same behavior when cold-launched by `ueli`.

@nathanshelly and I tested using the Electron `shell.openItem` API in a test app to launch Firefox, and it did not exhibit this behavior. We then discovered that disabling "Hide window after execution" in the `ueli` settings fixed this behavior, so we suspect it may be some weird interplay between apps with certain accessibility types and how Electron handles window and app hiding. We've discovered in the past that Firefox sometimes uses non-standard attributes on its windows, which caused [trouble in another app](https://github.com/lwouis/alt-tab-macos/issues/360).

Rather than try and unwind why hiding the `ueli` window/app interferes with Firefox/preference panes, this change seems to ensure they are foregrounded always.