### PR TITLE
the road to strict mode: enable strictPropertyInitialization

### DIFF
--- a/src/main/plugins/color-converter-plugin/color-converter-plugin.ts
+++ b/src/main/plugins/color-converter-plugin/color-converter-plugin.ts
@@ -11,7 +11,7 @@ import { IconType } from "../../../common/icon/icon-type";
 import { replaceWhitespace } from "../../../common/helpers/string-helpers";
 
 export class ColorConverterPlugin implements ExecutionPlugin {
-    public pluginType: PluginType.ColorConverter;
+    public pluginType = PluginType.ColorConverter;
     private config: ColorConverterOptions;
     private readonly clipboardCopier: (value: string) => Promise<void>;
 

--- a/src/main/plugins/control-panel-plugin/control-panel-item.ts
+++ b/src/main/plugins/control-panel-plugin/control-panel-item.ts
@@ -1,6 +1,6 @@
-export class ControlPanelItem {
-    public Name: string;
-    public CanonicalName: string;
-    public Description: string;
-    public IconBase64: string;
+export interface ControlPanelItem {
+    Name: string;
+    CanonicalName: string;
+    Description: string;
+    IconBase64: string;
 }

--- a/src/main/plugins/dictionary-plugin/dictionary-plugin.ts
+++ b/src/main/plugins/dictionary-plugin/dictionary-plugin.ts
@@ -19,7 +19,7 @@ export class DictionaryPlugin implements ExecutionPlugin {
     private config: DictionaryOptions;
     private readonly clipboardCopier: (value: string) => Promise<void>;
     private readonly definitionRetriever: (word: string) => Promise<Definition[]>;
-    private delay: NodeJS.Timeout | number;
+    private delay: NodeJS.Timeout | number | undefined;
 
     constructor(
         config: DictionaryOptions,

--- a/src/main/plugins/mdfind-plugin/mdfind-plugin.ts
+++ b/src/main/plugins/mdfind-plugin/mdfind-plugin.ts
@@ -9,7 +9,7 @@ import { Icon } from "../../../common/icon/icon";
 
 export class MdFindPlugin implements ExecutionPlugin, OpenLocationPlugin {
     public readonly pluginType = PluginType.MdFindExecutionPlugin;
-    private searchDelay: NodeJS.Timeout | number;
+    private searchDelay: NodeJS.Timeout | number | undefined;
 
     constructor(
         private config: MdFindOptions,

--- a/src/main/plugins/operating-system-settings-plugin/macos-operating-system-setting-repository.ts
+++ b/src/main/plugins/operating-system-settings-plugin/macos-operating-system-setting-repository.ts
@@ -8,7 +8,7 @@ import { generateMacAppIcons } from "../application-search-plugin/mac-os-app-ico
 import { executeCommandWithOutput } from "../../executors/command-executor";
 
 export class MacOsOperatingSystemSettingRepository implements OperatingSystemSettingRepository {
-    private all: OperatingSystemSetting[];
+    private all: OperatingSystemSetting[] = [];
 
     constructor() {
         this.getFilePaths()

--- a/src/main/plugins/translation-plugin/translation-plugin.ts
+++ b/src/main/plugins/translation-plugin/translation-plugin.ts
@@ -10,7 +10,7 @@ import { TranslationOptions } from "../../../common/config/translation-options";
 export class TranslationPlugin implements ExecutionPlugin {
     public readonly pluginType = PluginType.TranslationPlugin;
     private config: TranslationOptions;
-    private delay: NodeJS.Timeout | number;
+    private delay: NodeJS.Timeout | number | undefined;
     private readonly clipboardCopier: (value: string) => Promise<void>;
 
     constructor(config: TranslationOptions, clipboardCopier: (value: string) => Promise<void>) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
     "noImplicitAny": true, /* Raise error on expressions and declarations with an implied 'any' type. */
     "strictNullChecks": true, /* Enable strict null checks. */
     "resolveJsonModule": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "strictPropertyInitialization": true
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
     /* Additional Checks */


### PR DESCRIPTION
This PR enables `strictPropertyInitialization` flag for the typescript compiler, and makes the relevant code changes

This way, we can gradually enable flags, and eventually enable the comprehensive `strict` flag.
