### PR TITLE
Added "Powershell in Windows Terminal" to the commandline plugin

### DIFF
--- a/src/main/executors/commandline-executor.ts
+++ b/src/main/executors/commandline-executor.ts
@@ -53,6 +53,8 @@ export const windowsCommandLineExecutor = (command: string, shell: WindowsShell)
             return executeCommand(`start powershell -NoExit -Command "&${command}"`);
         case WindowsShell.Cmd:
             return executeCommand(`start cmd.exe /k "${command}"`);
+        case WindowsShell.PowerShellInWT:
+            return executeCommand(`start wt.exe powershell -NoExit -Command "&${command}"`);
         default:
             return unsupportedShellRejection(shell);
     }

--- a/src/main/plugins/commandline-plugin/shells.ts
+++ b/src/main/plugins/commandline-plugin/shells.ts
@@ -3,6 +3,7 @@ export enum WindowsShell {
     Powershell = "Powershell",
     PowerShellCore = "PowerShell Core",
     WSL = "WSL",
+    PowerShellInWT = "Powershell in Windows Terminal"
 }
 
 export enum MacOsShell {


### PR DESCRIPTION
Added the option to select "Powershell in Windows Terminal" as the shell in the commandline plugin.
This runs the command in Powershell in the new Windows Terminal