### PR TITLE
Phonetic converter plugin

### DIFF
--- a/.vscode/launch.example.json
+++ b/.vscode/launch.example.json
@@ -6,6 +6,9 @@
       "request": "launch",
       "name": "Electron Main",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+      "windows": {
+        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
+      },
       "program": "${workspaceRoot}/src/main/main.ts",
       "protocol": "inspector",
       "sourceMaps": true,

--- a/src/common/config/phonetic-converter-options.ts
+++ b/src/common/config/phonetic-converter-options.ts
@@ -1,0 +1,13 @@
+export interface PhoneticConverterOptions {
+  enabled: boolean;
+  prefix: string;
+  enableEnglish: boolean;
+  enableGerman: boolean;
+}
+
+export const defaultPhoneticConverterOptions: PhoneticConverterOptions = {
+  enabled: false,
+  prefix: "ph?",
+  enableEnglish: true,
+  enableGerman: false,
+};

--- a/src/common/config/user-config-options.ts
+++ b/src/common/config/user-config-options.ts
@@ -23,6 +23,7 @@ import { ApplicationSearchOptions, defaultApplicationSearchOptions } from "./app
 import { defaultDictionaryOptions, DictionaryOptions } from "./dictionary-options";
 import { BrowserBookmarksOptions, defaultBrowserBookmarksOptions } from "./browser-bookmarks-options";
 import { ControlPanelOptions, defaultControlPanelOptions } from "./control-panel-options";
+import { PhoneticConverterOptions, defaultPhoneticConverterOptions } from "./phonetic-converter-options";
 
 export interface UserConfigOptions {
     appearanceOptions: AppearanceOptions;
@@ -50,6 +51,7 @@ export interface UserConfigOptions {
     uwpSearchOptions: UwpSearchOptions;
     browserBookmarksOptions: BrowserBookmarksOptions;
     controlPanelOptions: ControlPanelOptions;
+    phoneticConverterOptions: PhoneticConverterOptions;
 }
 
 export const defaultUserConfigOptions: UserConfigOptions = {
@@ -78,4 +80,5 @@ export const defaultUserConfigOptions: UserConfigOptions = {
     uwpSearchOptions: defaultUwpSearchOptions,
     websearchOptions: defaultWebSearchOptions,
     workflowOptions: defaultWorkflowOptions,
+    phoneticConverterOptions: defaultPhoneticConverterOptions,
 };

--- a/src/common/icon/default-icons.ts
+++ b/src/common/icon/default-icons.ts
@@ -67,6 +67,11 @@ export const defaultTerminalIcon: Icon = {
     type: IconType.SVG,
 };
 
+export const defaultPhoneticIcon: Icon = {
+    parameter: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48" version="1.1"><g id="surface1"><path style=" fill:#CFD8DC;" d="M 41 6 L 7 6 C 6.398438 6 6 6.398438 6 7 L 6 42 L 42 42 L 42 7 C 42 6.398438 41.601563 6 41 6 Z "></path><path style=" fill:#263238;" d="M 8 13 L 40 13 L 40 40 L 8 40 Z "></path><path style=" fill:#CFD8DC;" d="M 22 20 L 18 34.5 L 21 34.5 L 24 23 L 27 34.5 L 30 34.5 L 26 20 Z "></path><path style=" fill:#CFD8DC;" d="M 20 29 L 28 29 L 28 31.5 L 20 31.5 Z "></path><path style=" fill:#5eb7e0;" d="M 13 30 L 18 30 L 17.5 32 L 13 32 Z "></path><path style=" fill:#5eb7e0;" d="M 11.5 26 L 19 26 L 18.5 28 L 11.5 28 Z "></path><path style=" fill:#5eb7e0;" d="M 10 22 L 20 22 L 19.5 24 L 10 24 Z "></path><path style=" fill:#5eb7e0;" d="M 30 30 L 36 30 L 36 32 L 30.5 32 Z "></path><path style=" fill:#5eb7e0;" d="M 29 26 L 37 26 L 37 28 L 29.5 28 Z "></path><path style=" fill:#5eb7e0;" d="M 28 22 L 38 22 L 38 24 L 28.5 24 Z "></path></g></svg>`,
+    type: IconType.SVG,
+};
+
 export const defaultShortcutIcon: Icon = {
     parameter: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48" version="1.1"><g id="surface1"><path style="fill:#3498DB;" d="M 43 19 L 29 31 L 29 7 Z "></path><path style="fill:#3498DB;" d="M 5 27 L 5 40 L 13 40 L 13 27 C 13 24.792969 14.792969 23 17 23 L 34 23 L 34 15 L 17 15 C 10.382813 15 5 20.382813 5 27 "></path></g></svg>`,
     type: IconType.SVG,

--- a/src/main/plugin-type.ts
+++ b/src/main/plugin-type.ts
@@ -21,6 +21,7 @@ export enum PluginType {
     Dictionary = "dictionary",
     BrowserBookmarks = "browser-bookmarks",
     ControlPanel = "control-panel-plugin",
+    PhoneticConverter = "phonetic-converter-plugin",
 
     // This is used for generic search results which do not have a specific plugin as a source
     None = "none",

--- a/src/main/plugins/phonetic-converter-plugin/phonetic-converter-plugin.ts
+++ b/src/main/plugins/phonetic-converter-plugin/phonetic-converter-plugin.ts
@@ -1,0 +1,102 @@
+// FIXME(flechnical): When typing too many characters the result text gets cut off. Find a way to cut off the result text at the left side or enable multi-line for results.
+
+import { ExecutionPlugin } from "../../execution-plugin";
+import { PluginType } from "../../plugin-type";
+import { SearchResultItem } from "../../../common/search-result-item";
+import { UserConfigOptions } from "../../../common/config/user-config-options";
+import { TranslationSet } from "../../../common/translation/translation-set";
+import { PhoneticConverterOptions } from "../../../common/config/phonetic-converter-options";
+import { defaultPhoneticIcon } from "../../../common/icon/default-icons";
+import { PhoneticConverter } from "./phonetic-converter";
+
+export class PhoneticConverterPlugin implements ExecutionPlugin {
+  public pluginType = PluginType.PhoneticConverter;
+  private config: PhoneticConverterOptions;
+  // private translationSet: TranslationSet;
+  private readonly clipboardCopier: (value: string) => Promise<void>;
+
+  constructor(
+    config: PhoneticConverterOptions,
+    // translationSet: TranslationSet,
+    clipboardCopier: (value: string) => Promise<void>
+  ) {
+    this.config = config;
+    // this.translationSet = translationSet;
+    this.clipboardCopier = clipboardCopier;
+  }
+
+  public isValidUserInput(userInput: string): boolean {
+    return (
+      userInput.startsWith(this.config.prefix) &&
+      userInput.replace(this.config.prefix, "").length > 0
+    );
+  }
+
+  public getSearchResults(
+    userInput: string,
+    fallback?: boolean | undefined
+  ): Promise<SearchResultItem[]> {
+    return new Promise((resolve, reject) => {
+      const strippedInput: string = userInput.replace(this.config.prefix, "");
+      const resultsArray: SearchResultItem[] = [];
+      if (this.config.enableEnglish) {
+        const englishResult: string = PhoneticConverter.convert(
+          strippedInput,
+          "eng"
+        );
+        resultsArray.push({
+          description: `Press enter to copy your input: ${strippedInput}`,
+          executionArgument: englishResult,
+          hideMainWindowAfterExecution: true,
+          icon: defaultPhoneticIcon,
+          name: `${englishResult}`,
+          originPluginType: this.pluginType,
+          searchable: [],
+        });
+      }
+      if (this.config.enableGerman) {
+        const germanResult: string = PhoneticConverter.convert(
+          strippedInput,
+          "ger"
+        );
+        resultsArray.push({
+          description: `Press enter to copy your input: ${strippedInput}`,
+          executionArgument: germanResult,
+          hideMainWindowAfterExecution: true,
+          icon: defaultPhoneticIcon,
+          name: `${germanResult}`,
+          originPluginType: this.pluginType,
+          searchable: [],
+        });
+      }
+      resolve(resultsArray);
+    });
+  }
+
+  public isEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  public execute(
+    searchResultItem: SearchResultItem,
+    privileged: boolean
+  ): Promise<void> {
+    return this.clipboardCopier(
+      searchResultItem.description.replace(
+        "Press enter to copy your input: ",
+        ""
+      )
+    ); // TODO(flechnical): adapt this so it also works with other languages; search for ": "?
+  }
+
+  public updateConfig(
+    updatedConfig: UserConfigOptions,
+    translationSet: TranslationSet
+  ): Promise<void> {
+    return new Promise((resolve) => {
+      this.config = updatedConfig.phoneticConverterOptions;
+      // this.translationSet = translationSet;
+      resolve();
+    });
+  }
+}

--- a/src/main/plugins/phonetic-converter-plugin/phonetic-converter.ts
+++ b/src/main/plugins/phonetic-converter-plugin/phonetic-converter.ts
@@ -1,0 +1,92 @@
+type PhoneticAlphabet = Record<string, string>;
+
+export class PhoneticConverter {
+
+  public static convert(input: string, lang: string): string {
+
+    let alphabet: PhoneticAlphabet;
+
+    const ENGLISH_ALPHABET: PhoneticAlphabet = {
+      a: "Alpha",
+      b: "Bravo",
+      c: "Charlie",
+      d: "Delta",
+      e: "Echo",
+      f: "Foxtrot",
+      g: "Golf",
+      h: "Hotel",
+      i: "India",
+      j: "Juliett",
+      k: "Kilo",
+      l: "Lima",
+      m: "Mike",
+      n: "November",
+      o: "Oscar",
+      p: "Papa",
+      q: "Quebec",
+      r: "Romeo",
+      s: "Sierra",
+      t: "Tango",
+      u: "Uniform",
+      v: "Victor",
+      w: "Whiskey",
+      x: "X-ray",
+      y: "Yankee",
+      z: "Zulu",
+      space: "[SPACE]",
+    };
+
+    const GERMAN_ALPHABET: PhoneticAlphabet = {
+      a: "Anton",
+      b: "Berta",
+      c: "Cäsar",
+      d: "Dora",
+      e: "Emil",
+      f: "Friedrich",
+      g: "Gustav",
+      h: "Heinrich",
+      i: "Ida",
+      j: "Julius",
+      k: "Konrad",
+      l: "Ludwig",
+      m: "Martha",
+      n: "Nordpol",
+      o: "Otto",
+      p: "Paula",
+      q: "Quelle",
+      r: "Richard",
+      s: "Siegfried",
+      t: "Theodor",
+      u: "Ulrich",
+      v: "Viktor",
+      w: "Wilhelm",
+      x: "Xaver",
+      y: "Ypsilon",
+      z: "Zeppelin",
+      space: "[LEER]",
+    };
+
+    switch (lang) {
+      case "eng":
+        alphabet = ENGLISH_ALPHABET;
+        break;
+      case "ger":
+        alphabet = GERMAN_ALPHABET;
+        break;
+      default:
+        alphabet = ENGLISH_ALPHABET;
+    }
+
+    return [...input.toLowerCase()]
+      .map((x: string) => {
+        if (x in alphabet) {
+          return alphabet[x];
+        } else {
+          if (x === " ") return alphabet.space;
+          else return x;
+        }
+      })
+      .join(" ");
+  }
+}
+

--- a/src/main/production/production-search-engine.ts
+++ b/src/main/production/production-search-engine.ts
@@ -55,6 +55,7 @@ import { everythingSearcher } from "../plugins/everything-plugin/everything-sear
 import { mdfindSearcher } from "../plugins/mdfind-plugin/mdfind-searcher";
 import { OperatingSystem, OperatingSystemVersion } from "../../common/operating-system";
 import { BraveBookmarkRepository } from "../plugins/browser-bookmarks-plugin/brave-bookmark-repository";
+import { PhoneticConverterPlugin } from "../plugins/phonetic-converter-plugin/phonetic-converter-plugin";
 
 export function getProductionSearchEngine(
     operatingSystem: OperatingSystem,
@@ -163,6 +164,7 @@ export function getProductionSearchEngine(
         new CommandlinePlugin(config.commandlineOptions, translationSet, commandlineExecutor, logger),
         new ColorConverterPlugin(config.colorConverterOptions, electronClipboardCopier),
         new DictionaryPlugin(config.dictionaryOptions, electronClipboardCopier, getGoogleDictionaryDefinitions),
+        new PhoneticConverterPlugin(config.phoneticConverterOptions, electronClipboardCopier),
     ];
 
     const fallbackPlugins: ExecutionPlugin[] = [

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -60,6 +60,7 @@ import { PluginType } from "../main/plugin-type";
 import { dictionarySettingsComponent } from "./settings/dictionary-settings-component";
 import { browserBookmarkSettingsComponent } from "./settings/browser-bookmark-settings-component";
 import { controlPanelSettingsComponent } from "./settings/control-panel-settings-component";
+import { phoneticConverterSettingsComponent } from "./settings/phonetic-converter-settings-component";
 
 Vue.component("user-input", userInputComponent);
 Vue.component("search-results", searchResultsComponent);
@@ -105,6 +106,7 @@ Vue.component("color-converter-setttings", colorConverterSettingsComponent);
 Vue.component("plugin-toggle", pluginToggle);
 Vue.component("browser-bookmark-settings", browserBookmarkSettingsComponent);
 Vue.component("control-panel-settings", controlPanelSettingsComponent);
+Vue.component("phonetic-converter-settings", phoneticConverterSettingsComponent);
 
 const initialConfig = new ElectronStoreConfigRepository(deepCopy(defaultUserConfigOptions)).getConfig();
 

--- a/src/renderer/settings/phonetic-converter-settings-component.ts
+++ b/src/renderer/settings/phonetic-converter-settings-component.ts
@@ -1,0 +1,116 @@
+import Vue from "vue";
+import { vueEventDispatcher } from "../vue-event-dispatcher";
+import { VueEventChannels } from "../vue-event-channels";
+import { PluginSettings } from "./plugin-settings";
+import { UserConfigOptions } from "../../common/config/user-config-options";
+import { defaultPhoneticConverterOptions } from "../../common/config/phonetic-converter-options";
+import { TranslationSet } from "../../common/translation/translation-set"; // TODO(flechnical): add localization in settings page; only hard-coded English for now
+import { UserConfirmationDialogParams, UserConfirmationDialogType } from "./modals/user-confirmation-dialog-params";
+import { deepCopy } from "../../common/helpers/object-helpers";
+
+export const phoneticConverterSettingsComponent = Vue.extend({
+    data() {
+        return {
+            settingName: PluginSettings.PhoneticConverter,
+            visible: false,
+        };
+    },
+    methods: {
+        resetAll() {
+            const translations: TranslationSet = this.translations;
+            const userConfirmationDialogParams: UserConfirmationDialogParams = {
+                callback: () => {
+                    const config: UserConfigOptions = this.config;
+                    config.phoneticConverterOptions = deepCopy(defaultPhoneticConverterOptions);
+                    this.updateConfig();
+                },
+                message: translations.resetPluginSettingsToDefaultWarning,
+                modalTitle: translations.resetToDefault,
+                type: UserConfirmationDialogType.Default,
+            };
+            vueEventDispatcher.$emit(VueEventChannels.settingsConfirmation, userConfirmationDialogParams);
+        },
+        toggleEnabled() {
+            const config: UserConfigOptions = this.config;
+            config.phoneticConverterOptions.enabled = !config.phoneticConverterOptions.enabled;
+            this.updateConfig();
+        },
+        updateConfig() {
+            vueEventDispatcher.$emit(VueEventChannels.configUpdated, this.config);
+        },
+    },
+    mounted() {
+        vueEventDispatcher.$on(VueEventChannels.showSetting, (settingName: string) => {
+            if (settingName === this.settingName) {
+                this.visible = true;
+            } else {
+                this.visible = false;
+            }
+        });
+    },
+    props: ["config", "translations"],
+    template: `
+        <div v-if="visible">
+            <div class="settings__setting-title title is-3">
+                <span>
+                    ICAO/NATO Phonetic Alphabet Converter
+                </span>
+                <div>
+                    <plugin-toggle :is-enabled="config.phoneticConverterOptions.enabled" :toggled="toggleEnabled"/>
+                    <button v-if="config.phoneticConverterOptions.enabled" class="button" @click="resetAll">
+                        <span class="icon"><i class="fas fa-undo-alt"></i></span>
+                    </button>
+                </div>
+            </div>
+            <p class="settings__setting-description">This plugin converts your input into the words of the ICAO/NATO Phonetic Alphabet or your preferred localized equivalent. You can copy the original input by pressing [Enter].</p>
+            <div class="settings__setting-content" >
+                <div v-if="!config.phoneticConverterOptions.enabled" class="settings__setting-disabled-overlay"></div>
+                <div class="box">
+                    <div class="settings__option-container">
+
+                    <div class="settings__option">
+                        <div class="settings__option-name">Prefix</div>
+                        <div class="settings__option-content">
+                            <div class="field is-grouped is-grouped-right">
+                                <div class="control">
+                                    <input
+                                        type="text"
+                                        class="input font-mono"
+                                        v-model="config.phoneticConverterOptions.prefix"
+                                        @change="updateConfig"
+                                    >
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="settings__option">
+                        <div class="settings__option-name">Enable English Alphabet</div>
+                        <div class="settings__option-content">
+                            <div class="field has-addons has-addons-right vertical-center">
+                                <div class="control">
+                                    <input id="enableEnglishCheckbox" type="checkbox" name="enableEnglishCheckbox" class="switch is-rounded is-success" checked="checked" v-model="config.phoneticConverterOptions.enableEnglish" @change="updateConfig">
+                                    <label for="enableEnglishCheckbox"></label>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="settings__option">
+                        <div class="settings__option-name">Enable German Alphabet</div>
+                        <div class="settings__option-content">
+                            <div class="field has-addons has-addons-right vertical-center">
+                                <div class="control">
+                                    <input id="enableGermanCheckbox" type="checkbox" name="enableGermanCheckbox" class="switch is-rounded is-success" checked="checked" v-model="config.phoneticConverterOptions.enableGerman" @change="updateConfig">
+                                    <label for="enableGermanCheckbox"></label>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+    `,
+});

--- a/src/renderer/settings/plugin-settings.ts
+++ b/src/renderer/settings/plugin-settings.ts
@@ -16,4 +16,5 @@ export enum PluginSettings {
     ColorConverter = "Color Converter",
     BrowserBookmarks = "Browser Bookmarks",
     Dictionary = "Dictionary",
+    PhoneticConverter = "Phonetic Converter"
 }

--- a/src/renderer/settings/setting-menu-item-component.ts
+++ b/src/renderer/settings/setting-menu-item-component.ts
@@ -121,6 +121,8 @@ export const settingMenuItemComponent = Vue.extend({
                     return config.websearchOptions.isEnabled;
                 case PluginSettings.Workflow:
                     return config.workflowOptions.isEnabled;
+                case PluginSettings.PhoneticConverter:
+                    return config.phoneticConverterOptions.enabled;
                 case SettingOsSpecific.ControlPanel.replace(`${platform()}:`, ""):
                     return config.controlPanelOptions.isEnabled;
                 case SettingOsSpecific.Everything.replace(`${platform()}:`, ""):

--- a/src/renderer/settings/settings-component.ts
+++ b/src/renderer/settings/settings-component.ts
@@ -140,6 +140,7 @@ export const settingsComponent = Vue.extend({
                 <user-confirmation :translations="translations"></user-confirmation>
                 <browser-bookmark-settings :config="config" :translations="translations"></browser-bookmark-settings>
                 <control-panel-settings :config="config" :translations="translations"></control-panel-settings>
+                <phonetic-converter-settings :config="config" :translations="translations"></phonetic-converter-settings>
             </div>
         </div>
     `,


### PR DESCRIPTION
I created a little plugin for converting user input into the NATO phonetic alphabet (activated by "ph?"). If that is a feature you want to consider for ueli, it would be great if you could take a look at my code. It is only for English and German at the moment, but it works great and can be used with multiple languages at once.

Great job on the code organisation by the way. It was very easy for a newbie like me to find any files I would have to integrate my plugin into (I only have a bit of web dev experience as a hobbyist). I just took the calculator-plugin as an example and looked for any occurrence of the word "calculator" in the code. Only with the translations, I wasn't sure, if I could implement it for the English and German settings pages only. Does it default to English if a translation is not available for e.g. Turkish?

If I made any mistakes/faux-pas in terms of TS or JS best practices, any tips are greatly appreciated.