### PR TITLE
Web search plugin improvements/fixes

### DIFF
--- a/src/main/executors/websearch-suggestion-resolver.ts
+++ b/src/main/executors/websearch-suggestion-resolver.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 
 export function getWebearchSuggestions(url: string): Promise<any> {
     return new Promise((resolve, reject) => {
-        axios.get(url)
+        axios.get(url, { headers: { "user-agent": "Mozilla/5.0" } })
             .then((response) => resolve(response.data))
             .catch((error) => reject(error));
     });

--- a/src/main/plugins/websearch-plugin/websearch-plugin.ts
+++ b/src/main/plugins/websearch-plugin/websearch-plugin.ts
@@ -55,8 +55,8 @@ export class WebSearchPlugin implements ExecutionPlugin {
 
                     for (const webSearchEngine of webSearchEngines) {
                         results.push({
-                            description: this.buildDescription(webSearchEngine, userInput),
-                            executionArgument: this.buildExecutionArgument(webSearchEngine, userInput),
+                            description: this.buildDescriptionFromUserInput(webSearchEngine, userInput),
+                            executionArgument: this.buildExecutionArgumentFromUserInput(webSearchEngine, userInput),
                             hideMainWindowAfterExecution: true,
                             icon: isValidIcon(webSearchEngine.icon) ? webSearchEngine.icon : defaultWebSearchIcon,
                             name: webSearchEngine.name,
@@ -95,24 +95,32 @@ export class WebSearchPlugin implements ExecutionPlugin {
         });
     }
 
-    private getSearchTerm(webSearchEngine: WebSearchEngine, userInput: string): string {
+    private buildDescriptionFromUserInput(webSearchEngine: WebSearchEngine, userInput: string): string {
+        return this.buildDescriptionFromSearchTerm(webSearchEngine, this.getSearchTerm(webSearchEngine, userInput, true));
+    }
+
+    private buildDescriptionFromSearchTerm(webSearchEngine: WebSearchEngine, searchTerm: string): string {
+        return this.translationSet.websearchDescription
+            .replace("{{websearch_engine}}", webSearchEngine.name)
+            .replace("{{search_term}}", searchTerm);
+    }
+
+    private getSearchTerm(webSearchEngine: WebSearchEngine, userInput: string, doNotEncode = false): string {
         let searchTerm = userInput.replace(webSearchEngine.prefix, "");
 
-        if (webSearchEngine.encodeSearchTerm) {
+        if (webSearchEngine.encodeSearchTerm && !doNotEncode) {
             searchTerm = encodeURIComponent(searchTerm);
         }
 
         return searchTerm;
     }
 
-    private buildDescription(webSearchEngine: WebSearchEngine, userInput: string): string {
-        return this.translationSet.websearchDescription
-            .replace("{{websearch_engine}}", webSearchEngine.name)
-            .replace("{{search_term}}", this.getSearchTerm(webSearchEngine, userInput));
+    private buildExecutionArgumentFromUserInput(webSearchEngine: WebSearchEngine, userInput: string): string {
+        return this.buildExecutionArgumentFromSearchTerm(webSearchEngine, this.getSearchTerm(webSearchEngine, userInput));
     }
 
-    private buildExecutionArgument(webSearchEngine: WebSearchEngine, userInput: string): string {
-        return this.replaceQueryInUrl(this.getSearchTerm(webSearchEngine, userInput), webSearchEngine.url);
+    private buildExecutionArgumentFromSearchTerm(webSearchEngine: WebSearchEngine, searchTerm: string): string {
+        return this.replaceQueryInUrl(searchTerm, webSearchEngine.url);
     }
 
     private userInputMatches(userInput: string, fallback?: boolean): boolean {
@@ -154,8 +162,8 @@ export class WebSearchPlugin implements ExecutionPlugin {
 
                         const searchResultItems = suggestions.map((suggestion): SearchResultItem => {
                             return {
-                                description: this.buildDescription(websearchEngine, suggestion),
-                                executionArgument: this.buildExecutionArgument(websearchEngine, suggestion),
+                                description: this.buildDescriptionFromSearchTerm(websearchEngine, suggestion),
+                                executionArgument: this.buildExecutionArgumentFromSearchTerm(websearchEngine, suggestion),
                                 hideMainWindowAfterExecution: true,
                                 icon: isValidIcon(websearchEngine.icon) ? websearchEngine.icon : defaultWebSearchIcon,
                                 name: suggestion,

--- a/src/main/plugins/websearch-plugin/websearch-plugin.ts
+++ b/src/main/plugins/websearch-plugin/websearch-plugin.ts
@@ -105,10 +105,10 @@ export class WebSearchPlugin implements ExecutionPlugin {
             .replace("{{search_term}}", searchTerm);
     }
 
-    private getSearchTerm(webSearchEngine: WebSearchEngine, userInput: string, doNotEncode = false): string {
+    private getSearchTerm(webSearchEngine: WebSearchEngine, userInput: string, skipEncoding = false): string {
         let searchTerm = userInput.replace(webSearchEngine.prefix, "");
 
-        if (webSearchEngine.encodeSearchTerm && !doNotEncode) {
+        if (webSearchEngine.encodeSearchTerm && !skipEncoding) {
             searchTerm = encodeURIComponent(searchTerm);
         }
 


### PR DESCRIPTION
Some improvements and fixes for the web search plugin:

1. Descriptions of results contained URL-encoded texts:

    ![grafik](https://user-images.githubusercontent.com/6824291/97037852-2f58d680-156a-11eb-88ca-d8ae52561dec.png)

   This doesn't look nice and encoding is only necessary for the search URL. So I don't encode the texts anymore:

    ![grafik](https://user-images.githubusercontent.com/6824291/97037960-5ca58480-156a-11eb-840e-9c4d4998520d.png)

2. If the search prefix was part of a suggestion, it was removed:

    ![grafik](https://user-images.githubusercontent.com/6824291/97038189-b312c300-156a-11eb-9a3d-e9294eaf43db.png)

    Now, the suggestion is correctly shown:

    ![grafik](https://user-images.githubusercontent.com/6824291/97038293-de95ad80-156a-11eb-8c99-5886f87b436c.png)

3. There was an encoding-related problem with Google suggestions:

    ![grafik](https://user-images.githubusercontent.com/6824291/97038360-fbca7c00-156a-11eb-9999-cbb82d3c7500.png)

    This could be fixed by setting a user agent...

    ![grafik](https://user-images.githubusercontent.com/6824291/97038409-13096980-156b-11eb-8021-ab7d7922faff.png)
