### PR TITLE
Use spawn to retrieve UWP apps

### DIFF
--- a/src/main/executors/command-executor.ts
+++ b/src/main/executors/command-executor.ts
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { exec, spawn } from "child_process";
 
 export function executeCommand(command: string): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -8,7 +8,7 @@ export function executeCommand(command: string): Promise<void> {
     });
 }
 
-export function executeCommandWithOutput(command: string): Promise<string> {
+export function executeCommandWithOutput(command: string): Promise<string> { 
     return new Promise((resolve, reject) => {
         exec(command, (err, stdout, stderr) => {
             if (err) {
@@ -19,5 +19,27 @@ export function executeCommandWithOutput(command: string): Promise<string> {
                 resolve(stdout);
             }
         });
+    });
+}
+
+export function spawnPowershellCommandWithOutput(command: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        let stdout = '';
+        let stderr = '';
+        const process = spawn('powershell.exe', ['-NoProfile', '-NonInteractive', '-c', command]);
+        process.on('error', (error) => reject(error));
+        process.on('exit', (code) => {
+            if (code === 0) {
+                resolve(stdout);
+            } else {
+                if (stderr) {
+                    reject(`Process exited with code ${code}. stderr: ${stderr}`);
+                } else {
+                    reject(`Process exited with code ${code}. stdout: ${stdout}`);
+                }
+            }
+        });
+        process.stdout.on('data', (chunk: string) => stdout += chunk);
+        process.stderr.on('data', (chunk: string) => stderr += chunk);
     });
 }

--- a/src/main/executors/command-executor.ts
+++ b/src/main/executors/command-executor.ts
@@ -8,7 +8,7 @@ export function executeCommand(command: string): Promise<void> {
     });
 }
 
-export function executeCommandWithOutput(command: string): Promise<string> { 
+export function executeCommandWithOutput(command: string): Promise<string> {
     return new Promise((resolve, reject) => {
         exec(command, (err, stdout, stderr) => {
             if (err) {


### PR DESCRIPTION
Use `child_process.spawn()` to retrieve UWP apps to avoid maxBuffer length exceeded error. This should fix #610.