### PR TITLE
Retrieve control panel icons with noProfile: true

### DIFF
--- a/src/main/plugins/control-panel-plugin/control-panel-items-retriever.ts
+++ b/src/main/plugins/control-panel-plugin/control-panel-items-retriever.ts
@@ -38,7 +38,7 @@ export class ControlPanelItemsRetriever {
                 } |
                 ConvertTo-Json
                     `;
-                    const shell = new Powershell({});
+                    const shell = new Powershell({ noProfile: true });
                     shell.addCommand(getIconsCommand)
                         .then(() => shell.invoke())
                         .then(


### PR DESCRIPTION
If a profile was present with outputs, it broke the control panel icon retrieval.