### PR TITLE
Execute workflow commands in default terminal

### DIFF
--- a/src/main/plugins/workflow-plugin/workflow-plugin.ts
+++ b/src/main/plugins/workflow-plugin/workflow-plugin.ts
@@ -8,21 +8,26 @@ import { WorkflowExecutionStep } from "./workflow-execution-argument";
 import { WorkflowExecutionArgumentType } from "./workflow-execution-argument-type";
 import { Workflow } from "./workflow";
 import { defaultWorkflowIcon } from "../../../common/icon/default-icons";
+import { WindowsShell, MacOsShell } from "../commandline-plugin/shells";
+import { CommandlineOptions } from "../../../common/config/commandline-options";
 
 export class WorkflowPlugin implements SearchPlugin {
     public pluginType = PluginType.Workflow;
     private config: WorkflowOptions;
+    private commandConfig: CommandlineOptions;
     private readonly filePathExecutor: (filePath: string, privileged?: boolean) => Promise<void>;
     private readonly urlExecutor: (url: string) => Promise<void>;
-    private readonly commandlineExecutor: (command: string) => Promise<void>;
+    private readonly commandlineExecutor: (command: string, shell: WindowsShell | MacOsShell) => Promise<void>;
 
     constructor(
         config: WorkflowOptions,
+        commandConfig: CommandlineOptions,
         filePathExecutor: (filePath: string, privileged?: boolean) => Promise<void>,
         urlExecutor: (url: string) => Promise<void>,
-        commandlineExecutor: (command: string) => Promise<void>,
+        commandlineExecutor: (command: string, shell: WindowsShell | MacOsShell) => Promise<void>,
     ) {
         this.config = config;
+        this.commandConfig = commandConfig;
         this.filePathExecutor = filePathExecutor;
         this.urlExecutor = urlExecutor;
         this.commandlineExecutor = commandlineExecutor;
@@ -88,7 +93,7 @@ export class WorkflowPlugin implements SearchPlugin {
     private handleExecutionStep(executionStep: WorkflowExecutionStep): Promise<void> {
         switch (executionStep.executionArgumentType) {
             case WorkflowExecutionArgumentType.CommandlineTool:
-                return this.commandlineExecutor(executionStep.executionArgument);
+                return this.commandlineExecutor(executionStep.executionArgument, this.commandConfig.shell);
             case WorkflowExecutionArgumentType.FilePath:
                 return this.filePathExecutor(executionStep.executionArgument);
             case WorkflowExecutionArgumentType.URL:

--- a/src/main/plugins/workflow-plugin/workflow-plugin.ts
+++ b/src/main/plugins/workflow-plugin/workflow-plugin.ts
@@ -14,20 +14,20 @@ import { CommandlineOptions } from "../../../common/config/commandline-options";
 export class WorkflowPlugin implements SearchPlugin {
     public pluginType = PluginType.Workflow;
     private config: WorkflowOptions;
-    private commandConfig: CommandlineOptions;
+    private commandlineOptions: CommandlineOptions;
     private readonly filePathExecutor: (filePath: string, privileged?: boolean) => Promise<void>;
     private readonly urlExecutor: (url: string) => Promise<void>;
     private readonly commandlineExecutor: (command: string, shell: WindowsShell | MacOsShell) => Promise<void>;
 
     constructor(
         config: WorkflowOptions,
-        commandConfig: CommandlineOptions,
+        commandlineOptions: CommandlineOptions,
         filePathExecutor: (filePath: string, privileged?: boolean) => Promise<void>,
         urlExecutor: (url: string) => Promise<void>,
         commandlineExecutor: (command: string, shell: WindowsShell | MacOsShell) => Promise<void>,
     ) {
         this.config = config;
-        this.commandConfig = commandConfig;
+        this.commandlineOptions = commandlineOptions;
         this.filePathExecutor = filePathExecutor;
         this.urlExecutor = urlExecutor;
         this.commandlineExecutor = commandlineExecutor;
@@ -93,7 +93,7 @@ export class WorkflowPlugin implements SearchPlugin {
     private handleExecutionStep(executionStep: WorkflowExecutionStep): Promise<void> {
         switch (executionStep.executionArgumentType) {
             case WorkflowExecutionArgumentType.CommandlineTool:
-                return this.commandlineExecutor(executionStep.executionArgument, this.commandConfig.shell);
+                return this.commandlineExecutor(executionStep.executionArgument, this.commandlineOptions.shell);
             case WorkflowExecutionArgumentType.FilePath:
                 return this.filePathExecutor(executionStep.executionArgument);
             case WorkflowExecutionArgumentType.URL:

--- a/src/main/production/production-search-engine.ts
+++ b/src/main/production/production-search-engine.ts
@@ -144,9 +144,10 @@ export function getProductionSearchEngine(
         ),
         new WorkflowPlugin(
             config.workflowOptions,
+            config.commandlineOptions,
             filePathExecutor,
             urlExecutor,
-            executeCommand,
+            commandlineExecutor,
         ),
         new SimpleFolderSearchPlugin(
             config.simpleFolderSearchOptions,


### PR DESCRIPTION
Hi,

While working with the Workflows I noticed that the commands where not firing in the terminal.  Maybe it is the kind of commands I wanted to run - but not much seemed to be happening for me.

The workflow command is now mimicking the commandline-plugin.  This change has been tested with iTerm on a Mac.  I noticed that if there are a few commands back to back they will execute on the same window. 

Related?
https://github.com/oliverschwendener/ueli/issues/644