### PR TITLE
"Reboot" triggers system restart #638

### DIFF
--- a/src/main/plugins/operating-system-commands-plugin/windows-operating-system-command-repository.ts
+++ b/src/main/plugins/operating-system-commands-plugin/windows-operating-system-command-repository.ts
@@ -44,7 +44,7 @@ export class WindowsOperatingSystemCommandRepository implements OperatingSystemC
                     type: IconType.SVG,
                 },
                 name: this.translationSet.windowsRestart,
-                searchable: [this.translationSet.windowsRestart],
+                searchable: [this.translationSet.windowsRestart, "reboot"],
             },
             {
                 description: this.translationSet.windowsSignoutDescription,


### PR DESCRIPTION
Now both "Restart" and "Reboot" trigger a suggests a system restart for windows. Did not include halt for shutdown as it is not a widely used term for shutdown, it could also be confused for sleep/hibernate