### PR TITLE
Also works without "in" or "to" keywords

### DIFF
--- a/src/main/plugins/currency-converter-plugin/currency-converter-plugin.ts
+++ b/src/main/plugins/currency-converter-plugin/currency-converter-plugin.ts
@@ -31,7 +31,17 @@ export class CurrencyConverterPlugin implements ExecutionPlugin {
     public isValidUserInput(userInput: string, fallback?: boolean | undefined): boolean {
         const keywords = ["in", "to"];
         const words = userInput.trim().split(" ");
-        if (words.length === 4) {
+        if (words.length === 3) {
+            try {
+                return (
+                    !isNaN(this.getNumber(words[0])) &&
+                    this.isCurrencyCode(words[1]) &&
+                    this.isCurrencyCode(words[2])
+                );
+            } catch (err) {
+                return false;
+            }
+        } else if (words.length === 4) {
             try {
                 return (
                     keywords.includes(words[2].toLowerCase()) &&
@@ -105,14 +115,26 @@ export class CurrencyConverterPlugin implements ExecutionPlugin {
 
     private buildCurrencyConversion(userInput: string): CurrencyConversion {
         const words = userInput.trim().split(" ");
-        return {
-            base:
-                Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[1].toLowerCase()) ||
-                CurrencyCode.EUR,
-            target:
-                Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[3].toLowerCase()) ||
-                CurrencyCode.USD,
-            value: this.getNumber(words[0]),
-        };
+        if (words.length === 3) {
+            return {
+                base:
+                    Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[1].toLowerCase()) ||
+                    CurrencyCode.EUR,
+                target:
+                    Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[2].toLowerCase()) ||
+                    CurrencyCode.USD,
+                value: this.getNumber(words[0]),
+            };
+        } else{
+            return {
+                base:
+                    Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[1].toLowerCase()) ||
+                    CurrencyCode.EUR,
+                target:
+                    Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[3].toLowerCase()) ||
+                    CurrencyCode.USD,
+                value: this.getNumber(words[0]),
+            };
+        }
     }
 }


### PR DESCRIPTION
The first word after the number is treated as the base currency and the second is treated as the target currency.

![image](https://user-images.githubusercontent.com/50170066/124681679-f32f9100-dec0-11eb-9214-1f18ddcffa86.png)
