### PR TITLE
Display search results only if they were retrieved for last user input

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -86,6 +86,7 @@ let trayIcon: Tray;
 let mainWindow: BrowserWindow;
 let settingsWindow: BrowserWindow;
 let lastWindowPosition = config.generalOptions.lastWindowPosition;
+let lastSearchUserInput: string | undefined;
 
 let translationSet = getTranslationSet(config.generalOptions.language);
 const logger = appIsInDevelopment ? new DevLogger() : new ProductionLogger(logFilePath, filePathExecutor);
@@ -715,9 +716,14 @@ function registerAllIpcListeners() {
     );
 
     ipcMain.on(IpcChannels.search, (event: Electron.IpcMainEvent, userInput: string) => {
+        lastSearchUserInput = userInput;
         searchEngine
             .getSearchResults(userInput)
-            .then((result) => updateSearchResults(result, event.sender))
+            .then((result) => {
+                if (lastSearchUserInput === userInput) {
+                    updateSearchResults(result, event.sender);
+                }
+            })
             .catch((err) => {
                 logger.error(err);
                 noSearchResultsFound();


### PR DESCRIPTION
Discard search results if they were not retrieved for the latest user input.

This should fix #778 and #665.