### PR TITLE
Fix links to the old dictionary API in readme/settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This plugin enables you to quickly convert currencies. The latest conversion rat
 
 ### Dictionary
 
-This plugin enables you to quickly look up the definition and synonyms of words. It uses an unofficial Google Dictionary API (https://googledictionaryapi.eu-gb.mybluemix.net/)
+This plugin enables you to quickly look up the definition and synonyms of words. It uses an unofficial Google Dictionary API (https://dictionaryapi.dev/)
 
 ![dictionary](assets/feature-dictionary.png)
 

--- a/src/common/translation/chinese-translation-set.ts
+++ b/src/common/translation/chinese-translation-set.ts
@@ -335,7 +335,7 @@ export const chineseTranslationSet: TranslationSet = {
     colorConverterShowColorPreview: "显示颜色预览",
 
     dictionary: "字典",
-    dictionaryDescription: "使用 Google 字典 API (https://googledictionaryapi.eu-gb.mybluemix.net/) 进行英文释义",
+    dictionaryDescription: "使用 Google 字典 API (https://dictionaryapi.dev/) 进行英文释义",
     dictionaryPrefix: "前缀",
     dictionaryMinSearchTermLength: "单词最短长度",
     dictionaryDebounceDelay: "防抖动（毫秒）",

--- a/src/common/translation/english-translation-set.ts
+++ b/src/common/translation/english-translation-set.ts
@@ -343,7 +343,7 @@ export const englishTranslationSet: TranslationSet = {
 
     dictionary: "Dictionary",
     dictionaryDescription:
-        "This plugin enables you to quickly look up the definition and synonyms of words. It uses an unofficial Google Dictionary API (https://googledictionaryapi.eu-gb.mybluemix.net/)",
+        "This plugin enables you to quickly look up the definition and synonyms of words. It uses an unofficial Google Dictionary API (https://dictionaryapi.dev/)",
     dictionaryPrefix: "Prefix",
     dictionaryMinSearchTermLength: "Min search term length",
     dictionaryDebounceDelay: "Debounce delay (in milliseconds)",

--- a/src/common/translation/german-translation-set.ts
+++ b/src/common/translation/german-translation-set.ts
@@ -346,7 +346,7 @@ export const germanTranslationSet: TranslationSet = {
 
     dictionary: "Wörterbuch",
     dictionaryDescription:
-        "Dieses Plugin erlaubt es dir die Definition und Synonyme eines Wortes nachzuschlagen. Es benutzt eine inoffizielle API für Google Dictionary (https://googledictionaryapi.eu-gb.mybluemix.net/)",
+        "Dieses Plugin erlaubt es dir die Definition und Synonyme eines Wortes nachzuschlagen. Es benutzt eine inoffizielle API für Google Dictionary (https://dictionaryapi.dev/)",
     dictionaryPrefix: "Präfix",
     dictionaryMinSearchTermLength: "Minimum Suchbegrifflänge",
     dictionaryDebounceDelay: "Debounce Verzögerung (in Millisekunden)",

--- a/src/common/translation/japanese-translation-set.ts
+++ b/src/common/translation/japanese-translation-set.ts
@@ -341,7 +341,7 @@ export const japaneseTranslationSet: TranslationSet = {
 
     dictionary: "辞書",
     dictionaryDescription:
-        "このプラグインは単語の定義や同義語を素早く調べることができます。非公式の Google Dictionary API (https://googledictionaryapi.eu-gb.mybluemix.net/) を使用します。",
+        "このプラグインは単語の定義や同義語を素早く調べることができます。非公式の Google Dictionary API (https://dictionaryapi.dev/) を使用します。",
     dictionaryPrefix: "プレフィックス",
     dictionaryMinSearchTermLength: "検索語の最小長さ",
     dictionaryDebounceDelay: "デバウンス遅延 (ミリ秒)",

--- a/src/common/translation/korean-translation-set.ts
+++ b/src/common/translation/korean-translation-set.ts
@@ -339,7 +339,7 @@ export const koreanTranslationSet: TranslationSet = {
 
     dictionary: "사전",
     dictionaryDescription:
-        "이 플러그인은 단어의 정의와 동의어를 빠르게 검색할 수 있게 해줍니다. 비공식 구글 사전 API (https://googledictionaryapi.eu-gb.mybluemix.net/)를 사용합니다.",
+        "이 플러그인은 단어의 정의와 동의어를 빠르게 검색할 수 있게 해줍니다. 비공식 구글 사전 API (https://dictionaryapi.dev/)를 사용합니다.",
     dictionaryPrefix: "접두어",
     dictionaryMinSearchTermLength: "검색어 최소 길이",
     dictionaryDebounceDelay: "디바운스 지연 시간 (밀리 초 단위)",

--- a/src/common/translation/portuguese-translation-set.ts
+++ b/src/common/translation/portuguese-translation-set.ts
@@ -347,7 +347,7 @@ export const portugueseTranslationSet: TranslationSet = {
 
     dictionary: "Dicionário",
     dictionaryDescription:
-        "Este plugin te habilita a checar rapidamente definições e sinônimos de palavras. Ele usa uma API não-oficial do Google Dictionary (https://googledictionaryapi.eu-gb.mybluemix.net/)",
+        "Este plugin te habilita a checar rapidamente definições e sinônimos de palavras. Ele usa uma API não-oficial do Google Dictionary (https://dictionaryapi.dev/)",
     dictionaryPrefix: "Prefixo",
     dictionaryMinSearchTermLength: "Tamanho mínimo do termo de pesquisa",
     dictionaryDebounceDelay: "Tempo de resposta (em milisegundos)",

--- a/src/common/translation/russian-translation-set.ts
+++ b/src/common/translation/russian-translation-set.ts
@@ -340,7 +340,7 @@ export const russianTranslationSet: TranslationSet = {
 
     dictionary: "Словарь",
     dictionaryDescription:
-        "Этот плагин позволяет быстро искать значения слов и синонимы к ним. Он использует неофициальное API Google Dictionary (https://googledictionaryapi.eu-gb.mybluemix.net/)",
+        "Этот плагин позволяет быстро искать значения слов и синонимы к ним. Он использует неофициальное API Google Dictionary (https://dictionaryapi.dev/)",
     dictionaryPrefix: "Префикс",
     dictionaryMinSearchTermLength: "Минимальная длинна запроса",
     dictionaryDebounceDelay: "Задержка между запросами (в миллисекундах)",

--- a/src/common/translation/spanish-translation-set.ts
+++ b/src/common/translation/spanish-translation-set.ts
@@ -348,7 +348,7 @@ export const spanishTranslationSet: TranslationSet = {
 
     dictionary: "Diccionario",
     dictionaryDescription:
-        "Este plugin te permite buscar de forma rápida en las deficiones y sinónimos de palabras. Usa un API no oficial de Google Dictionary (https://googledictionaryapi.eu-gb.mybluemix.net/)",
+        "Este plugin te permite buscar de forma rápida en las deficiones y sinónimos de palabras. Usa un API no oficial de Google Dictionary (https://dictionaryapi.dev/)",
     dictionaryPrefix: "Prefijo",
     dictionaryMinSearchTermLength: "Longitud mínima del término de búsqueda",
     dictionaryDebounceDelay: "Retraso de rebote (en milisegundos)",

--- a/src/common/translation/turkish-translation-set.ts
+++ b/src/common/translation/turkish-translation-set.ts
@@ -347,7 +347,7 @@ export const turkishTranslationSet: TranslationSet = {
 
     dictionary: "Sözlük",
     dictionaryDescription:
-        "Bu eklenti, kelimelerin tanımını ve eş anlamlılarını hızlı bir şekilde aramanızı sağlar. Resmi olmayan bir Google Sözlük API'i kullanıyor (https://googledictionaryapi.eu-gb.mybluemix.net/)",
+        "Bu eklenti, kelimelerin tanımını ve eş anlamlılarını hızlı bir şekilde aramanızı sağlar. Resmi olmayan bir Google Sözlük API'i kullanıyor (https://dictionaryapi.dev/)",
     dictionaryPrefix: "Ön ek",
     dictionaryMinSearchTermLength: "Minimum arama terimi uzunluğu",
     dictionaryDebounceDelay: "Hata gecikmesi (milisaniye cinsinden)",


### PR DESCRIPTION
The API change happened in #459 but the links in the README and settings page were never updated