### PR TITLE
Handle errors of all plugins during index refresh

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -118,7 +118,11 @@ function refreshAllIndexes() {
             notifyRenderer(translationSet.successfullyRefreshedIndexes, NotificationType.Info);
         })
         .catch((err) => {
-            logger.error(err);
+            if (Array.isArray(err)) {
+                err.forEach(e => logger.error(e));
+            } else {
+                logger.error(err);
+            }
             notifyRenderer(err, NotificationType.Error);
         })
         .finally(onIndexRefreshFinished);

--- a/src/main/search-engine.ts
+++ b/src/main/search-engine.ts
@@ -139,11 +139,16 @@ export class SearchEngine {
 
     public refreshAllIndexes(): Promise<void> {
         return new Promise((resolve, reject) => {
-            Promise.all(
-                this.searchPlugins.filter((plugin) => plugin.isEnabled()).map((plugin) => plugin.refreshIndex()),
-            )
-                .then(() => resolve())
-                .catch((err) => reject(err));
+            Promise
+                .allSettled(this.searchPlugins.filter((plugin) => plugin.isEnabled()).map((plugin) => plugin.refreshIndex()))
+                .then((results) => {
+                    const failures = results.filter(r => r.status === 'rejected') as PromiseRejectedResult[];
+                    if (failures.length > 0) {
+                        reject(failures.map(f => f.reason));
+                    } else {
+                        resolve();
+                    }
+                });
         });
     }
 


### PR DESCRIPTION
Currently, when triggering a manual index refresh and one of the plugins throws an error, the `Refreshing indexes...` indication is immediately removed, even if index refreshing of other plugins is still ongoing. Also, only the first error is logged, even if multiple plugins throw errors.

This fixes the issue by using `Promise.allSettled()` instead of `Promise.all()`.