### PR TITLE
Get favicon from websearch url

### DIFF
--- a/src/renderer/settings/icon-component.ts
+++ b/src/renderer/settings/icon-component.ts
@@ -26,9 +26,6 @@ export const iconComponent = Vue.extend({
             }
             return "";
         },
-        onIconLoadFailureFallback() {
-          this.icon = this.defaultIcon;
-        }
     },
     props: ["icon", "defaulticon"],
     template: `

--- a/src/renderer/settings/icon-component.ts
+++ b/src/renderer/settings/icon-component.ts
@@ -9,11 +9,12 @@ export const iconComponent = Vue.extend({
             iconTypeColor: IconType.Color,
             iconTypeSvg: IconType.SVG,
             iconTypeUrl: IconType.URL,
+            iconUrlFail: false,
         };
     },
     methods: {
         getIcon(icon: Icon) {
-            if (isValidIcon(icon)) {
+            if (isValidIcon(icon) && this.iconUrlFail === false) {
                 return icon;
             } else {
                 return this.defaulticon;
@@ -25,11 +26,14 @@ export const iconComponent = Vue.extend({
             }
             return "";
         },
+        onIconLoadFailureFallback() {
+          this.icon = this.defaultIcon;
+        }
     },
     props: ["icon", "defaulticon"],
     template: `
         <div class="settings-table__icon-container">
-            <img v-if="getIcon(icon).type === iconTypeUrl" :src="getIcon(icon).parameter" class="settings-table__icon-url">
+            <img v-if="getIcon(icon).type === iconTypeUrl" :src="getIcon(icon).parameter" @error="iconUrlFail=true" class="settings-table__icon-url">
             <div v-if="getIcon(icon).type === iconTypeSvg" v-html="getIcon(icon).parameter" class="settings-table__icon-svg"></div>
             <div v-if="getIcon(icon).type === iconTypeColor" :style="getBackgroundColor(icon)" class="settings-table__icon-color"></div>
         </div>

--- a/src/renderer/settings/modals/websearch-editing-modal-component.ts
+++ b/src/renderer/settings/modals/websearch-editing-modal-component.ts
@@ -50,6 +50,17 @@ export const websearchEditingModal = Vue.extend({
                 );
             }
         },
+        onUrlBlurGetFaviconUrl() {
+          const websearchEngine: WebSearchEngine = this.websearchEngine;
+          if (websearchEngine.url.length > 0) {
+            try {
+              const url = new URL(websearchEngine.url);
+              websearchEngine.icon.parameter = `${url.protocol}//${url.hostname}/favicon.ico`;
+            } catch {
+              websearchEngine.icon.parameter = "";
+            }
+          }
+        },
         getModalTitle(): string {
             const editMode: ModalEditMode = this.editMode;
             const translations: TranslationSet = this.translations;
@@ -121,7 +132,7 @@ export const websearchEditingModal = Vue.extend({
                             {{ translations.websearchUrl }}
                         </label>
                         <div class="control is-expanded">
-                            <input class="input" type="url" v-model="websearchEngine.url" :placeholder="getUrlPlaceholder()">
+                            <input class="input" type="url" v-model="websearchEngine.url" :placeholder="getUrlPlaceholder()" v-on:blur="onUrlBlurGetFaviconUrl()">
                         </div>
                     </div>
 

--- a/src/renderer/settings/modals/websearch-editing-modal-component.ts
+++ b/src/renderer/settings/modals/websearch-editing-modal-component.ts
@@ -132,7 +132,7 @@ export const websearchEditingModal = Vue.extend({
                             {{ translations.websearchUrl }}
                         </label>
                         <div class="control is-expanded">
-                            <input class="input" type="url" v-model="websearchEngine.url" :placeholder="getUrlPlaceholder()" v-on:blur="onUrlBlurGetFaviconUrl()">
+                            <input class="input" type="url" v-model="websearchEngine.url" :placeholder="getUrlPlaceholder()" @blur="onUrlBlurGetFaviconUrl()">
                         </div>
                     </div>
 


### PR DESCRIPTION
Given a domain `https://[website].[domain]`. We can grab the favicon using it's url with `https://[website].[domain]/favicon.ico`.

Alongside this implementation is a fallback to the default icon if the favicon doesn't exist on `icon-component.ts`. 

Based on issue #574 which I created. After the user inputs the url and exits, the Image URL section will auto fill with the `favicon` url. 

Example of change:
![2021-10-14_19-32-50](https://user-images.githubusercontent.com/62213594/137409610-1a4d25f3-c991-409c-b38a-c204fff44533.gif)