### PR TITLE
Use translated string for font size settings.

### DIFF
--- a/src/renderer/settings/appearance-settings-component.ts
+++ b/src/renderer/settings/appearance-settings-component.ts
@@ -176,7 +176,7 @@ export const appearanceSettingsComponent = Vue.extend({
                     </div>
 
                     <div class="settings__option">
-                        <div class="settings__option-name">Font Size</div>
+                        <div class="settings__option-name">{{ translations.appearanceSettingsUserInputFontSize }}</div>
                         <div class="settings__option-content">
                             <div class="field is-grouped is-grouped-right">
                                 <div class="control">
@@ -283,7 +283,7 @@ export const appearanceSettingsComponent = Vue.extend({
                     </div>
 
                     <div class="settings__option">
-                        <div class="settings__option-name">Font Size</div>
+                        <div class="settings__option-name">{{ translations.appearanceSettingsSearchResultDescriptionFontSize }}</div>
                         <div class="settings__option-content">
                             <div class="field is-grouped is-grouped-right">
                                 <div class="control">
@@ -305,7 +305,7 @@ export const appearanceSettingsComponent = Vue.extend({
                     </div>
 
                     <div class="settings__option">
-                        <div class="settings__option-name">Font Size</div>
+                        <div class="settings__option-name">{{ translations.appearanceSettingsSearchResultNameFontSize }}</div>
                         <div class="settings__option-content">
                             <div class="field is-grouped is-grouped-right">
                                 <div class="control">


### PR DESCRIPTION
Option labels for Font Size setting (User input, Search result name and description)  are not translated.
It might be unintentional omission 😃 