### PR TITLE
[Calculator] Handle mathjs evaluating to null

### DIFF
--- a/src/main/plugins/calculator-plugin/calculator.test.ts
+++ b/src/main/plugins/calculator-plugin/calculator.test.ts
@@ -61,6 +61,15 @@ describe(Calculator.name, () => {
                 expect(actual).toBe(expected);
             });
         });
+
+        it("should handle null", () => {
+            const precision = 16;
+            const calculation = "null";
+            const expected = "null";
+
+            const result = Calculator.calculate(calculation, precision);
+            expect(result).toBe(expected);
+        });
     });
 
     describe(Calculator.isValidInput.name, () => {

--- a/src/main/plugins/calculator-plugin/calculator.ts
+++ b/src/main/plugins/calculator-plugin/calculator.ts
@@ -52,12 +52,12 @@ export class Calculator {
         const math = this.math(precision);
 
         if (!math.evaluate) {
-            throw new Error("Failed to instanciate math js static");
+            throw new Error("Failed to instantiate math js static");
         }
 
-        const result: string = math
-            .evaluate(this.normalizeInput(input, decimalSeparator, argumentSeparator))
-            .toString();
+        const result: string = String(
+            math.evaluate(this.normalizeInput(input, decimalSeparator, argumentSeparator)),
+        );
 
         return result.replace(new RegExp(",|\\.", "g"), (match) =>
             match === "." ? decimalSeparator : argumentSeparator,


### PR DESCRIPTION
math.js supports the symbol `null`, so `math.evaluate('null') === null`.

Typing `null` in ueli gives an exception, and the log says `Cannot read property 'toString' of null`.
ueli tries to convert the evaluation result to a string, so instead of `result.toString()` I changed it to `String(result)` to support `null`