### PR TITLE
Application search: ignore wildcard characters in paths

### DIFF
--- a/src/main/executors/application-searcher.ts
+++ b/src/main/executors/application-searcher.ts
@@ -20,15 +20,16 @@ export function searchWindowsApplications(
         const utf8Encoding = "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8";
         const ignoreErrors = "$ErrorActionPreference = 'SilentlyContinue'";
         const createApplicationsArray = "$applications = New-Object Collections.Generic.List[String]";
+        const extensions = applicationSearchOptions.applicationFileExtensions.map((e) => `'${e}'`).join(",");
+        const createExtensionsHashSet = `$extensions = New-Object System.Collections.Generic.HashSet[string] ([string[]]@(${extensions}), [System.StringComparer]::OrdinalIgnoreCase)`
         const folders = applicationSearchOptions.applicationFolders
             .map((applicationFolder) => `'${applicationFolder}'`)
             .join(",");
-        const extensionFilter = applicationSearchOptions.applicationFileExtensions.map((e) => `*${e}`).join(", ");
-        const getChildItem = `Get-ChildItem -Path $_ -include ${extensionFilter} -Recurse -File | % { $applications.Add($_.FullName) }`;
+        const getChildItem = `Get-ChildItem -LiteralPath $_ -Recurse -File | Where-Object { $extensions.Contains($_.Extension) } | ForEach-Object { $applications.Add($_.FullName) }`;
         const createResult = `$result = (@{ errors = @($error | ForEach-Object { $_.Exception.Message }); applications = $applications } | ConvertTo-Json)`;
         const printResult = "Write-Host $result";
-        const powershellScript = `${utf8Encoding}; ${ignoreErrors}; ${createApplicationsArray}; ${folders} | %{ ${getChildItem} }; ${createResult}; ${printResult};`;
-        const command = `powershell -NonInteractive -NoProfile -Command "& { ${powershellScript} }"`;
+        const powershellScript = `${utf8Encoding}; ${ignoreErrors}; ${createApplicationsArray}; ${createExtensionsHashSet}; ${folders} | %{ ${getChildItem} }; ${createResult}; ${printResult};`;
+        const command = `powershell.exe -NonInteractive -NoProfile -Command "& { ${powershellScript} }"`;
         executeCommandWithOutput(command)
             .then((resultOutput: string) => {
                 const result: { errors: string[]; applications: string[] } = JSON.parse(resultOutput);


### PR DESCRIPTION
This fixes the new issue posted in #343 by using `Get-ChildItem` with `-LiteralPath` to ignore wildcard characters. `-Include` does not work with `-LiteralPath` so I use `Where-Object` instead. Besides this improves the performance by around 40% (on my system from ~1270 ms to ~750 ms).