### PR TITLE
Default Target Currency

### DIFF
--- a/src/common/config/currency-converter-options.ts
+++ b/src/common/config/currency-converter-options.ts
@@ -1,9 +1,13 @@
+import { CurrencyCode } from "../../main/plugins/currency-converter-plugin/currency-code";
+
 export interface CurrencyConverterOptions {
     precision: number;
+    defaultTarget: CurrencyCode;
     isEnabled: boolean;
 }
 
 export const defaultCurrencyConverterOptions: CurrencyConverterOptions = {
     isEnabled: false,
     precision: 2,
+    defaultTarget: CurrencyCode.EUR
 };

--- a/src/main/plugins/currency-converter-plugin/currency-converter-plugin.ts
+++ b/src/main/plugins/currency-converter-plugin/currency-converter-plugin.ts
@@ -31,29 +31,39 @@ export class CurrencyConverterPlugin implements ExecutionPlugin {
     public isValidUserInput(userInput: string, fallback?: boolean | undefined): boolean {
         const keywords = ["in", "to"];
         const words = userInput.trim().split(" ");
-        if (words.length === 3) {
-            try {
-                return (
-                    !isNaN(this.getNumber(words[0])) &&
-                    this.isCurrencyCode(words[1]) &&
-                    this.isCurrencyCode(words[2])
-                );
-            } catch (err) {
-                return false;
+        switch (words.length) {
+            case 2: {
+                try {
+                    return (!isNaN(this.getNumber(words[0])) && this.isCurrencyCode(words[1]));
+                } catch (err) {
+                    return false;
+                }
             }
-        } else if (words.length === 4) {
-            try {
-                return (
-                    keywords.includes(words[2].toLowerCase()) &&
-                    !isNaN(this.getNumber(words[0])) &&
-                    this.isCurrencyCode(words[1]) &&
-                    this.isCurrencyCode(words[3])
-                );
-            } catch (err) {
-                return false;
+            case 3: {
+                try {
+                    return (
+                        !isNaN(this.getNumber(words[0])) &&
+                        this.isCurrencyCode(words[1]) &&
+                        this.isCurrencyCode(words[2])
+                    );
+                } catch (err) {
+                    return false;
+                }
             }
-        } else {
-            return false;
+            case 4: {
+                try {
+                    return (
+                        keywords.includes(words[2].toLowerCase()) &&
+                        !isNaN(this.getNumber(words[0])) &&
+                        this.isCurrencyCode(words[1]) &&
+                        this.isCurrencyCode(words[3])
+                    );
+                } catch (err) {
+                    return false;
+                }
+            }
+            default:
+                return false;
         }
     }
 
@@ -115,26 +125,38 @@ export class CurrencyConverterPlugin implements ExecutionPlugin {
 
     private buildCurrencyConversion(userInput: string): CurrencyConversion {
         const words = userInput.trim().split(" ");
-        if (words.length === 3) {
-            return {
-                base:
-                    Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[1].toLowerCase()) ||
-                    CurrencyCode.EUR,
-                target:
-                    Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[2].toLowerCase()) ||
-                    CurrencyCode.USD,
-                value: this.getNumber(words[0]),
-            };
-        } else{
-            return {
-                base:
-                    Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[1].toLowerCase()) ||
-                    CurrencyCode.EUR,
-                target:
-                    Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[3].toLowerCase()) ||
-                    CurrencyCode.USD,
-                value: this.getNumber(words[0]),
-            };
+        switch (words.length) {
+            case 2: {
+                return {
+                    base:
+                        Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[1].toLowerCase()) ||
+                        CurrencyCode.EUR,
+                    target: this.config.defaultTarget,
+                    value: this.getNumber(words[0]),
+                };
+            }
+            case 3: {
+                return {
+                    base:
+                        Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[1].toLowerCase()) ||
+                        CurrencyCode.EUR,
+                    target:
+                        Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[2].toLowerCase()) ||
+                        CurrencyCode.USD,
+                    value: this.getNumber(words[0]),
+                };
+            }
+            default: {
+                return {
+                    base:
+                        Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[1].toLowerCase()) ||
+                        CurrencyCode.EUR,
+                    target:
+                        Object.values(CurrencyCode).find((c: CurrencyCode) => c.toLowerCase() === words[3].toLowerCase()) ||
+                        CurrencyCode.USD,
+                    value: this.getNumber(words[0]),
+                };
+            }
         }
     }
 }

--- a/src/renderer/settings/currency-converter-settings-component.ts
+++ b/src/renderer/settings/currency-converter-settings-component.ts
@@ -7,11 +7,13 @@ import { PluginSettings } from "./plugin-settings";
 import { TranslationSet } from "../../common/translation/translation-set";
 import { UserConfirmationDialogParams, UserConfirmationDialogType } from "./modals/user-confirmation-dialog-params";
 import { deepCopy } from "../../common/helpers/object-helpers";
+import { CurrencyCode } from "../../main/plugins/currency-converter-plugin/currency-code";
 
 export const currencyConverterSettingsComponent = Vue.extend({
     data() {
         return {
             settingName: PluginSettings.CurrencyConverter,
+            currencyCodes: Object.values(CurrencyCode),
             visible: false,
         };
     },
@@ -84,6 +86,21 @@ export const currencyConverterSettingsComponent = Vue.extend({
                             </div>
                         </div>
                     </div>
+
+                    <div class="settings__option">
+                            <div class="settings__option-name">Default Currency Target</div>
+                            <div class="settings__option-content">
+                                <div class="field is-grouped is-grouped-right">
+                                    <div class="control">
+                                        <div class="select">
+                                            <select v-model="config.currencyConverterOptions.defaultTarget" @change="updateConfig">
+                                                <option v-for="currencyCode in currencyCodes">{{ currencyCode }}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
 
                 </div>
             </div>


### PR DESCRIPTION
## Added the option for setting a default target currency.
Hey there! I would like to add the feature "Default Target Currency".
I love using ueli and do so every single day. One of the (very few) things that I thought would be nice to have is the option for setting a default target currency.
### What I did
- Added an option in the settings window under the Currency Converter plugin. The option allows a person to set a default target currency.
- Added the necessary code for checking the input and converting it correctly.

### Example
To see how the feature works, simply leave out the in/to keyword and the target currency:
![electron_rwcgnRrN0M](https://user-images.githubusercontent.com/31919921/152253787-6c2d1002-f851-42af-b702-62e9a34fa121.png)

### What I didn't do
- I did not add translations of the name of the option, since I unfortunately don't speak any of the supported languages.

I think it is ready to be merged (except the translation part), but I am of course happy to make any changes you see fit!
Hope you find my small contribution useful.

Thank you!