### PR TITLE
Add /System/Applications to default search path

### DIFF
--- a/src/common/config/application-search-options.ts
+++ b/src/common/config/application-search-options.ts
@@ -24,7 +24,12 @@ const windowsApplicationSearchOptions: ApplicationSearchOptions = {
 
 const macOsApplicationSearchOptions: ApplicationSearchOptions = {
     applicationFileExtensions: [".app"],
-    applicationFolders: ["/Applications", "/System/Library/CoreServices", `${homedir()}/Applications`],
+    applicationFolders: [
+        "/Applications",
+        "/System/Library/CoreServices",
+        "/System/Applications",
+        `${homedir()}/Applications`,
+    ],
     enabled: true,
     showFullFilePath: false,
     useNativeIcons: true,


### PR DESCRIPTION
Most macOS apps now seem to live in `/System/Applications` so this path should be added to the default setup so users can easily open QuickTime Player and TextEdit again.