### PR TITLE
Setup Crowdin

### DIFF
--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -1,0 +1,40 @@
+# This workflow will run Crowdin Action that will upload new texts to Crowdin, download the newest translations and create a PR
+# For more information see: https://github.com/crowdin/github-action
+
+name: Crowdin Action
+
+# Controls when the action will run.
+on:
+  schedule:
+    - cron: '0 */6 * * *' # Every 6 hours - https://crontab.guru/#0_*/6_*_*_*
+  push: #temporary
+    branches: [ dev ]
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: crowdin action
+        uses: crowdin/github-action@1.4.9
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+          # Upload translations to Crowdin, only use true at initial run
+          upload_translations: true
+          # Make pull request of Crowdin translations
+          download_translations: true
+          # To download translations to the specified version branch
+          localization_branch_name: l10n_crowdin_translations
+          # Create pull request after pushing to branch
+          create_pull_request: true
+          pull_request_title: 'New Crowdin translations'
+          pull_request_body: 'New Crowdin pull request with translations'
+          pull_request_base_branch_name: 'dev'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -5,8 +5,8 @@ name: Crowdin Action
 
 # Controls when the action will run.
 on:
-  schedule:
-    - cron: '0 */6 * * *' # Every 6 hours - https://crontab.guru/#0_*/6_*_*_*
+  # schedule:
+  #   - cron: '0 */6 * * *' # Every 6 hours - https://crontab.guru/#0_*/6_*_*_*
   push: #temporary
     branches: [ dev ]
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,29 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path": "."
+
+"preserve_hierarchy": true
+
+"files": [
+  {
+    "source": "src/common/translation/english-translation-set.ts",
+    "translation": "src/common/translation/%language%-translation-set.ts",
+    "languages_mapping": {
+      "language": {
+        "zh-CN": "chinese",
+        "cs": "czech",
+        "fi": "finnish",
+        "de": "german",
+        "hi": "hindi",
+        "it": "italian",
+        "ja": "japanese",
+        "ko": "korean",
+        "pt-PT": "portuguese",
+        "ru": "russian",
+        "es-ES": "spanish",
+        "tr": "turkish",
+        "uk": "ukrainian"
+      }
+    }
+  }
+]

--- a/src/common/translation/chinese-translation-set.ts
+++ b/src/common/translation/chinese-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const chineseTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "显示",
     trayIconSettings: "设置",
     trayIconQuit: "退出",

--- a/src/common/translation/czech-translation-set.ts
+++ b/src/common/translation/czech-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const englishTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "Zobrazit",
     trayIconSettings: "Nastavení",
     trayIconQuit: "Ukončit",

--- a/src/common/translation/english-translation-set.ts
+++ b/src/common/translation/english-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const englishTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "Show",
     trayIconSettings: "Settings",
     trayIconQuit: "Quit",

--- a/src/common/translation/finnish-translation-set.ts
+++ b/src/common/translation/finnish-translation-set.ts
@@ -1,7 +1,7 @@
 import { TranslationSet } from "./translation-set";
 
 // tslint:disable:object-literal-sort-keys for better readability
-export const finnishTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "Näytä",
     trayIconSettings: "Asetukset",
     trayIconQuit: "Lopeta",

--- a/src/common/translation/german-translation-set.ts
+++ b/src/common/translation/german-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const germanTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "Öffnen",
     trayIconSettings: "Einstellungen",
     trayIconQuit: "Beenden",

--- a/src/common/translation/hindi-translation-set.ts
+++ b/src/common/translation/hindi-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const hindiTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "दिखाएं",
     trayIconSettings: "सेटिंगस",
     trayIconQuit: "बंद करें",

--- a/src/common/translation/italian-translation-set.ts
+++ b/src/common/translation/italian-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const italianTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "Mostra",
     trayIconSettings: "Impostazioni",
     trayIconQuit: "Esci",

--- a/src/common/translation/japanese-translation-set.ts
+++ b/src/common/translation/japanese-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const japaneseTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "表示",
     trayIconSettings: "設定",
     trayIconQuit: "終了",

--- a/src/common/translation/korean-translation-set.ts
+++ b/src/common/translation/korean-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const koreanTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "보이기",
     trayIconSettings: "설정",
     trayIconQuit: "종료",

--- a/src/common/translation/portuguese-translation-set.ts
+++ b/src/common/translation/portuguese-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const portugueseTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "Mostrar",
     trayIconSettings: "Configurações",
     trayIconQuit: "Sair",

--- a/src/common/translation/russian-translation-set.ts
+++ b/src/common/translation/russian-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const russianTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "Открыть",
     trayIconSettings: "Настройки",
     trayIconQuit: "Выйти",

--- a/src/common/translation/spanish-translation-set.ts
+++ b/src/common/translation/spanish-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const spanishTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "Mostrar",
     trayIconSettings: "Configuración",
     trayIconQuit: "Salir",

--- a/src/common/translation/translation-set-manager.ts
+++ b/src/common/translation/translation-set-manager.ts
@@ -1,48 +1,51 @@
-import { chineseTranslationSet } from "./chinese-translation-set";
-import { englishTranslationSet } from "./english-translation-set";
-import { finnishTranslationSet } from "./finnish-translation-set";
-import { germanTranslationSet } from "./german-translation-set";
-import { hindiTranslationSet } from "./hindi-translation-set";
-import { italianTranslationSet } from "./italian-translation-set";
-import { japaneseTranslationSet } from "./japanese-translation-set";
-import { koreanTranslationSet } from "./korean-translation-set";
+import * as chineseTranslationSet from "./chinese-translation-set";
+import * as englishTranslationSet from "./english-translation-set";
+import * as finnishTranslationSet from "./finnish-translation-set";
+import * as germanTranslationSet from "./german-translation-set";
+import * as hindiTranslationSet from "./hindi-translation-set";
+import * as italianTranslationSet from "./italian-translation-set";
+import * as japaneseTranslationSet from "./japanese-translation-set";
+import * as koreanTranslationSet from "./korean-translation-set";
 import { Language } from "./language";
-import { portugueseTranslationSet } from "./portuguese-translation-set";
-import { russianTranslationSet } from "./russian-translation-set";
-import { spanishTranslationSet } from "./spanish-translation-set";
+import * as portugueseTranslationSet from "./portuguese-translation-set";
+import * as russianTranslationSet from "./russian-translation-set";
+import * as spanishTranslationSet from "./spanish-translation-set";
 import { TranslationSet } from "./translation-set";
-import { turkishTranslationSet } from "./turkish-translation-set";
-import { ukrainianTranslationSet } from "./ukrainian-translation-set";
+import * as turkishTranslationSet from "./turkish-translation-set";
+import * as ukrainianTranslationSet from "./ukrainian-translation-set";
+import * as czechTranslationSet from "./czech-translation-set";
 
 export function getTranslationSet(language: Language): TranslationSet {
     switch (language) {
         case Language.English:
-            return englishTranslationSet;
+            return englishTranslationSet.translationSet;
         case Language.Finnish:
-            return finnishTranslationSet;
+            return finnishTranslationSet.translationSet;
         case Language.German:
-            return germanTranslationSet;
+            return germanTranslationSet.translationSet;
         case Language.Hindi:
-            return hindiTranslationSet;
+            return hindiTranslationSet.translationSet;
         case Language.Portuguese:
-            return portugueseTranslationSet;
+            return portugueseTranslationSet.translationSet;
         case Language.Russian:
-            return russianTranslationSet;
+            return russianTranslationSet.translationSet;
         case Language.Turkish:
-            return turkishTranslationSet;
+            return turkishTranslationSet.translationSet;
         case Language.Spanish:
-            return spanishTranslationSet;
+            return spanishTranslationSet.translationSet;
         case Language.Chinese:
-            return chineseTranslationSet;
+            return chineseTranslationSet.translationSet;
         case Language.Korean:
-            return koreanTranslationSet;
+            return koreanTranslationSet.translationSet;
         case Language.Japanese:
-            return japaneseTranslationSet;
+            return japaneseTranslationSet.translationSet;
         case Language.Italian:
-            return italianTranslationSet;
+            return italianTranslationSet.translationSet;
         case Language.Ukrainian:
-            return ukrainianTranslationSet;
+            return ukrainianTranslationSet.translationSet;
+        case Language.Czech:
+            return czechTranslationSet.translationSet;
         default:
-            return englishTranslationSet;
+            return englishTranslationSet.translationSet;
     }
 }

--- a/src/common/translation/turkish-translation-set.ts
+++ b/src/common/translation/turkish-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const turkishTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "Göster",
     trayIconSettings: "Ayarlar",
     trayIconQuit: "Çıkış",

--- a/src/common/translation/ukrainian-translation-set.ts
+++ b/src/common/translation/ukrainian-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const ukrainianTranslationSet: TranslationSet = {
+export const translationSet: TranslationSet = {
     trayIconShow: "Відкрити",
     trayIconSettings: "Налаштування",
     trayIconQuit: "Вийти",

--- a/src/main/search-engine.test.ts
+++ b/src/main/search-engine.test.ts
@@ -1,6 +1,6 @@
 import { SearchEngine } from "./search-engine";
 import { SearchPlugin } from "./search-plugin";
-import { englishTranslationSet } from "../common/translation/english-translation-set";
+import * as englishTranslationSet from "../common/translation/english-translation-set";
 import { FakeSearchPlugin } from "../tests/fake-search-plugin";
 import { FakeExecutionPlugin } from "../tests/fake-execution-plugin";
 import { SearchResultItem } from "../common/search-result-item";
@@ -34,7 +34,7 @@ describe(SearchEngine.name, () => {
             [],
             defaultSearchEngineOptions,
             false,
-            englishTranslationSet,
+            englishTranslationSet.translationSet,
             fakeFavoritesRepository,
         );
 
@@ -60,7 +60,7 @@ describe(SearchEngine.name, () => {
                 searchable: ["Google Chrome"],
             },
         ];
-        const translationSet = englishTranslationSet;
+        const translationSet = englishTranslationSet.translationSet;
 
         const searchPlugins: SearchPlugin[] = [new FakeSearchPlugin(PluginType.Test, items, true)];
 
@@ -96,7 +96,7 @@ describe(SearchEngine.name, () => {
                 searchable: ["Google Chrome"],
             },
         ];
-        const translationSet = englishTranslationSet;
+        const translationSet = englishTranslationSet.translationSet;
 
         const searchPlugins: SearchPlugin[] = [new FakeSearchPlugin(PluginType.Test, items, true)];
 
@@ -132,7 +132,7 @@ describe(SearchEngine.name, () => {
                 searchable: ["Google Chrome"],
             },
         ];
-        const translationSet = englishTranslationSet;
+        const translationSet = englishTranslationSet.translationSet;
 
         const searchPlugins: SearchPlugin[] = [new FakeSearchPlugin(PluginType.Test, items, true)];
         const userOptions = { fuzzyness: 0.8 } as SearchEngineOptions;
@@ -170,7 +170,7 @@ describe(SearchEngine.name, () => {
                 searchable: ["Google Chrome"],
             },
         ];
-        const translationSet = englishTranslationSet;
+        const translationSet = englishTranslationSet.translationSet;
 
         const searchPlugins: SearchPlugin[] = [new FakeSearchPlugin(PluginType.Test, items, true)];
         const userOptions = { fuzzyness: 0.2 } as SearchEngineOptions;


### PR DESCRIPTION
Hey everyone,

Just did some analysis of the current i18n workflow and it feels like GitHub issues and PRs reported by the community are not so easy to handle. The community translators can work together in Crowdin, translations would be delivered as PR and volunteers can raise issues for problematic strings via Crowdin.

I'm suggesting the integration with Crowdin via GitHub Actions. Crowdin is free for open-source projects. This integration works in the following way:
- the action runs every 6 hours (actually, it's up to you what trigger to use, it could also be a push to the default branch, for example)
- upload new source texts to the Crowdin project
- upload existing translations to Crowdin (using the `upload_translations` action config parameter, it's necessary only for the first time)
- download all the new translations from Crowdin and commit these translations to the `localization_branch_name`
- open a Pull Request with the latest translations.

You can find my demo Crowdin project here - [ueli-demo](https://crowdin.com/project/ueli-demo).

Example of the first PR that will be created by Crowdin Action - https://github.com/andrii-bodnar/ueli/pull/1 (Don't worry about the diffs. Crowdin tries to save the initial file structure as much as possible but in the case of the `.ts` files, there is a compromise with the indentations. The next PRs will include new translations only)

Also, I made some improvements to the translation set manager since Crowdin can't replace the const name during file export.

Fixes #869