### PR TITLE
Make basic commands are searchable in English as well

### DIFF
--- a/src/main/plugins/operating-system-commands-plugin/mac-os-operating-system-command-repository.ts
+++ b/src/main/plugins/operating-system-commands-plugin/mac-os-operating-system-command-repository.ts
@@ -2,6 +2,7 @@ import { OperatingSystemCommand } from "./operating-system-command";
 import { IconType } from "../../../common/icon/icon-type";
 import { OperatingSystemCommandRepository } from "./operating-system-commands-repository";
 import { TranslationSet } from "../../../common/translation/translation-set";
+import { englishTranslationSet } from "../../../common/translation/english-translation-set";
 import { UserConfigOptions } from "../../../common/config/user-config-options";
 
 export class MacOsOperatingSystemCommandRepository implements OperatingSystemCommandRepository {
@@ -36,7 +37,7 @@ export class MacOsOperatingSystemCommandRepository implements OperatingSystemCom
                     type: IconType.SVG,
                 },
                 name: this.translationSet.macOsShutdown,
-                searchable: [this.translationSet.macOsShutdown],
+                searchable: [...new Set([this.translationSet.macOsShutdown, englishTranslationSet.macOsShutdown])],
             },
             {
                 description: this.translationSet.macOsRestartDescription,
@@ -48,7 +49,7 @@ export class MacOsOperatingSystemCommandRepository implements OperatingSystemCom
                     type: IconType.SVG,
                 },
                 name: this.translationSet.macOsRestart,
-                searchable: [this.translationSet.macOsRestart],
+                searchable: [...new Set([this.translationSet.macOsRestart, englishTranslationSet.macOsRestart])],
             },
             {
                 description: this.translationSet.macOsLogoutDescription,
@@ -62,7 +63,7 @@ export class MacOsOperatingSystemCommandRepository implements OperatingSystemCom
                     type: IconType.SVG,
                 },
                 name: this.translationSet.macOsLogout,
-                searchable: [this.translationSet.macOsLogout],
+                searchable: [...new Set([this.translationSet.macOsLogout, englishTranslationSet.macOsLogout])],
             },
             {
                 description: this.translationSet.macOsSleepDescription,
@@ -72,7 +73,7 @@ export class MacOsOperatingSystemCommandRepository implements OperatingSystemCom
                     type: IconType.SVG,
                 },
                 name: this.translationSet.macOsSleep,
-                searchable: [this.translationSet.macOsSleep],
+                searchable: [...new Set([this.translationSet.macOsSleep, englishTranslationSet.macOsSleep])],
             },
             {
                 description: this.translationSet.macOsLockDescription,
@@ -82,7 +83,7 @@ export class MacOsOperatingSystemCommandRepository implements OperatingSystemCom
                     type: IconType.SVG,
                 },
                 name: this.translationSet.macOsLock,
-                searchable: [this.translationSet.macOsLock],
+                searchable: [...new Set([this.translationSet.macOsLock, englishTranslationSet.macOsLock])],
             },
         ];
     }

--- a/src/main/plugins/operating-system-commands-plugin/windows-operating-system-command-repository.ts
+++ b/src/main/plugins/operating-system-commands-plugin/windows-operating-system-command-repository.ts
@@ -1,6 +1,7 @@
 import { OperatingSystemCommandRepository } from "./operating-system-commands-repository";
 import { OperatingSystemCommand } from "./operating-system-command";
 import { TranslationSet } from "../../../common/translation/translation-set";
+import { englishTranslationSet } from "../../../common/translation/english-translation-set";
 import { UserConfigOptions } from "../../../common/config/user-config-options";
 import { IconType } from "../../../common/icon/icon-type";
 
@@ -34,7 +35,7 @@ export class WindowsOperatingSystemCommandRepository implements OperatingSystemC
                     type: IconType.SVG,
                 },
                 name: this.translationSet.windowsShutdown,
-                searchable: [this.translationSet.windowsShutdown],
+                searchable: [...new Set([this.translationSet.windowsShutdown, englishTranslationSet.windowsShutdown])],
             },
             {
                 description: this.translationSet.windowsRestartDescription,
@@ -44,7 +45,7 @@ export class WindowsOperatingSystemCommandRepository implements OperatingSystemC
                     type: IconType.SVG,
                 },
                 name: this.translationSet.windowsRestart,
-                searchable: [this.translationSet.windowsRestart, this.translationSet.windowsReboot],
+                searchable: [this.translationSet.windowsRestart, this.translationSet.windowsReboot, englishTranslationSet.windowsRestart, englishTranslationSet.windowsReboot],
             },
             {
                 description: this.translationSet.windowsSignoutDescription,
@@ -54,7 +55,7 @@ export class WindowsOperatingSystemCommandRepository implements OperatingSystemC
                     type: IconType.SVG,
                 },
                 name: this.translationSet.windowsSignout,
-                searchable: [this.translationSet.windowsSignout],
+                searchable: [this.translationSet.windowsSignout, englishTranslationSet.windowsSignout],
             },
             {
                 description: this.translationSet.windowsLockDescription,
@@ -64,7 +65,7 @@ export class WindowsOperatingSystemCommandRepository implements OperatingSystemC
                     type: IconType.SVG,
                 },
                 name: this.translationSet.windowsLock,
-                searchable: [this.translationSet.windowsLock],
+                searchable: [this.translationSet.windowsLock, englishTranslationSet.windowsLock],
             },
             {
                 description: this.translationSet.windowsSleepDescription,
@@ -74,7 +75,7 @@ export class WindowsOperatingSystemCommandRepository implements OperatingSystemC
                     type: IconType.SVG,
                 },
                 name: this.translationSet.windowsSleep,
-                searchable: [this.translationSet.windowsSleep],
+                searchable: [this.translationSet.windowsSleep, englishTranslationSet.windowsSleep],
             },
             {
                 description: this.translationSet.windowsHibernationDescription,
@@ -84,7 +85,7 @@ export class WindowsOperatingSystemCommandRepository implements OperatingSystemC
                     type: IconType.SVG,
                 },
                 name: this.translationSet.windowsHibernation,
-                searchable: [this.translationSet.windowsHibernation],
+                searchable: [this.translationSet.windowsHibernation, englishTranslationSet.windowsHibernation],
             },
         ];
     }

--- a/src/main/plugins/ueli-command-search-plugin/ueli-command-search-plugin.ts
+++ b/src/main/plugins/ueli-command-search-plugin/ueli-command-search-plugin.ts
@@ -8,6 +8,7 @@ import { UeliCommandExecutionArgument } from "./ueli-command-execution-argument"
 import { ipcMain } from "electron";
 import { IpcChannels } from "../../../common/ipc-channels";
 import { TranslationSet } from "../../../common/translation/translation-set";
+import { englishTranslationSet } from "../../../common/translation/english-translation-set";
 
 export class UeliCommandSearchPlugin implements SearchPlugin {
     public readonly pluginType = PluginType.UeliCommandSearchPlugin;
@@ -81,7 +82,7 @@ export class UeliCommandSearchPlugin implements SearchPlugin {
             },
             name: ueliCommand.name,
             originPluginType: this.pluginType,
-            searchable: [ueliCommand.name],
+            searchable: ueliCommand.searchable,
         };
     }
 
@@ -92,36 +93,42 @@ export class UeliCommandSearchPlugin implements SearchPlugin {
                 executionArgument: UeliCommandExecutionArgument.Exit,
                 hideMainWindowAfterExecution: true,
                 name: this.translationSet.ueliCommandExit,
+                searchable: [...new Set([this.translationSet.ueliCommandExit, englishTranslationSet.ueliCommandExit])],
             },
             {
                 description: this.translationSet.ueliCommandReloadDescription,
                 executionArgument: UeliCommandExecutionArgument.Reload,
                 hideMainWindowAfterExecution: false,
                 name: this.translationSet.ueliCommandReload,
+                searchable: [...new Set([this.translationSet.ueliCommandReload, englishTranslationSet.ueliCommandReload])],
             },
             {
                 description: this.translationSet.ueliCommandEditSettingsFileDescription,
                 executionArgument: UeliCommandExecutionArgument.EditConfigFile,
                 hideMainWindowAfterExecution: true,
                 name: this.translationSet.ueliCommandEditSettingsFile,
+                searchable: [...new Set([this.translationSet.ueliCommandEditSettingsFile, englishTranslationSet.ueliCommandEditSettingsFile])],
             },
             {
                 description: this.translationSet.ueliCommandOpenSettingsDescription,
                 executionArgument: UeliCommandExecutionArgument.OpenSettings,
                 hideMainWindowAfterExecution: false,
                 name: this.translationSet.ueliCommandOpenSettings,
+                searchable: [...new Set([this.translationSet.ueliCommandOpenSettings, englishTranslationSet.ueliCommandOpenSettings])],
             },
             {
                 description: this.translationSet.ueliCommandRefreshIndexesDescription,
                 executionArgument: UeliCommandExecutionArgument.RefreshIndexes,
                 hideMainWindowAfterExecution: false,
                 name: this.translationSet.ueliCommandRefreshIndexes,
+                searchable: [...new Set([this.translationSet.ueliCommandRefreshIndexes, englishTranslationSet.ueliCommandRefreshIndexes])],
             },
             {
                 description: this.translationSet.ueliCommandClearCachesDescription,
                 executionArgument: UeliCommandExecutionArgument.ClearCaches,
                 hideMainWindowAfterExecution: false,
                 name: this.translationSet.ueliCommandClearCaches,
+                searchable: [...new Set([this.translationSet.ueliCommandClearCaches, englishTranslationSet.ueliCommandClearCaches])],
             },
         ];
     }

--- a/src/main/plugins/ueli-command-search-plugin/ueli-command.ts
+++ b/src/main/plugins/ueli-command-search-plugin/ueli-command.ts
@@ -5,4 +5,5 @@ export interface UeliCommand {
     description: string;
     executionArgument: UeliCommandExecutionArgument;
     hideMainWindowAfterExecution: boolean;
+    searchable: string[];
 }


### PR DESCRIPTION
Ueli Commands and Operating System Commands are searchable by a string translated into the selected language, but these basic commands may want to be searched in English. 

Probably there are many who think that way in any language... Perhaps https://github.com/oliverschwendener/ueli/issues/591 is such a request.

This PR make those commands are searchable by not only translated but also english string.

ex: In Japanese and English
![image](https://user-images.githubusercontent.com/1698606/188603745-d81571a9-7a88-4355-80b8-d809b02d19b5.png)
![image](https://user-images.githubusercontent.com/1698606/188603789-acc5e9dc-f3fa-42fe-ba1f-40beab8220e2.png)

