### PR TITLE
Skip updating the config on window move if we are not tracking last window position

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -518,7 +518,7 @@ function destroyTrayIcon() {
 }
 
 function onMainWindowMove() {
-    if (windowExists(mainWindow)) {
+    if (windowExists(mainWindow) && config.generalOptions.rememberWindowPosition) {
         const currentPosition = mainWindow.getPosition();
         if (currentPosition.length === 2) {
             lastWindowPosition = {


### PR DESCRIPTION
If we are not tracking the last window position (`config.generalConfig.rememberWindowPosition == false`), skip updating the config with `config.generalConfig.lastWindowPosition`.

---

For context, I personally store my `config.json` in a Git repo where I track some config files. Since I regularly move between using my laptop with monitors and on the laptop screen, the `lastWindowPosition` updates often, which creates a diff in that repo. However, I have `rememberWindowPosition` disabled.

It's a mild annoyance to reset those changes when I end up with a diff :)