### PR TITLE
Custom shell support for windows

### DIFF
--- a/src/common/config/commandline-options.ts
+++ b/src/common/config/commandline-options.ts
@@ -5,20 +5,29 @@ import { OperatingSystem } from "../operating-system";
 
 export interface CommandlineOptions {
     isEnabled: boolean;
+    isCustom: boolean;
     prefix: string;
     shell: WindowsShell | MacOsShell;
+    customShell: string;
+    customShellFlags: string;
 }
 
 const defaultMacOsCommandlineOptions: CommandlineOptions = {
     isEnabled: true,
+    isCustom: false,
     prefix: ">",
     shell: MacOsShell.Terminal,
+    customShell: '',
+    customShellFlags: ''
 };
 
 const defaultWindowsCommandlineOptions: CommandlineOptions = {
     isEnabled: true,
+    isCustom: false,
     prefix: ">",
     shell: WindowsShell.Cmd,
+    customShell: '',
+    customShellFlags: ''
 };
 
 export const defaultCommandlineOptions: CommandlineOptions =

--- a/src/main/executors/commandline-executor.ts
+++ b/src/main/executors/commandline-executor.ts
@@ -61,3 +61,14 @@ export const windowsCommandLineExecutor = (command: string, shell: WindowsShell)
             return unsupportedShellRejection(shell);
     }
 };
+
+export const macOsCommandLineCustomShellExecutor = (command: string, shell: string, flags: string): Promise<void> => {
+    return Promise.reject('Custom shell is not supported in your platform');
+}
+
+export const windowsCommandLineCustomShellExecutor = (command: string, shell: string, flags: string): Promise<void> => {
+    const executionParams = flags.includes('{command}') ?
+        flags.replace('{command}', command) :
+        `${flags} "${command}"`
+    return executeCommand(`start "" /D %HOMEPATH% "${shell}" ${executionParams}`)
+};

--- a/src/main/plugins/commandline-plugin/commandline-plugin.ts
+++ b/src/main/plugins/commandline-plugin/commandline-plugin.ts
@@ -15,6 +15,7 @@ export class CommandlinePlugin implements ExecutionPlugin {
         private config: CommandlineOptions,
         private translationSet: TranslationSet,
         private readonly commandlineExecutor: (command: string, shell: WindowsShell | MacOsShell) => Promise<void>,
+        private readonly commandlineCustomShellExecutor: (command: string, shell: string, flags: string) => Promise<void>,
         private readonly logger: Logger,
     ) {}
 
@@ -43,7 +44,11 @@ export class CommandlinePlugin implements ExecutionPlugin {
     }
 
     public execute(searchResultItem: SearchResultItem): Promise<void> {
-        this.commandlineExecutor(searchResultItem.executionArgument, this.config.shell)
+        const execution = this.config.isCustom ?
+            this.commandlineCustomShellExecutor(searchResultItem.executionArgument, this.config.customShell, this.config.customShellFlags) :
+            this.commandlineExecutor(searchResultItem.executionArgument, this.config.shell)
+
+        execution
             .then(() => {
                 /* do nothing */
             })

--- a/src/main/production/production-search-engine.ts
+++ b/src/main/production/production-search-engine.ts
@@ -29,7 +29,12 @@ import { CurrencyConverterPlugin } from "../plugins/currency-converter-plugin/cu
 import { executeCommand } from "../executors/command-executor";
 import { WorkflowPlugin } from "../plugins/workflow-plugin/workflow-plugin";
 import { CommandlinePlugin } from "../plugins/commandline-plugin/commandline-plugin";
-import { macOsCommandLineExecutor, windowsCommandLineExecutor } from "../executors/commandline-executor";
+import {
+    macOsCommandLineExecutor,
+    windowsCommandLineExecutor,
+    windowsCommandLineCustomShellExecutor,
+    macOsCommandLineCustomShellExecutor
+} from "../executors/commandline-executor";
 import { OperatingSystemSettingsPlugin } from "../plugins/operating-system-settings-plugin/operating-system-settings-plugin";
 import { MacOsOperatingSystemSettingRepository } from "../plugins/operating-system-settings-plugin/macos-operating-system-setting-repository";
 import {
@@ -82,6 +87,8 @@ export function getProductionSearchEngine(
     const urlExecutor = openUrlInBrowser;
     const commandlineExecutor =
         operatingSystem === OperatingSystem.Windows ? windowsCommandLineExecutor : macOsCommandLineExecutor;
+    const commandLineCustomShellExecutor =
+        operatingSystem === OperatingSystem.Windows ? windowsCommandLineCustomShellExecutor : macOsCommandLineCustomShellExecutor;
     const operatingSystemSettingsRepository =
         operatingSystem === OperatingSystem.Windows
             ? new WindowsOperatingSystemSettingRepository()
@@ -218,7 +225,7 @@ export function getProductionSearchEngine(
         new UrlPlugin(config.urlOptions, translationSet, urlExecutor),
         new EmailPlugin(config.emailOptions, translationSet, urlExecutor),
         new CurrencyConverterPlugin(config, translationSet, electronClipboardCopier),
-        new CommandlinePlugin(config.commandlineOptions, translationSet, commandlineExecutor, logger),
+        new CommandlinePlugin(config.commandlineOptions, translationSet, commandlineExecutor, commandLineCustomShellExecutor, logger),
         new ColorConverterPlugin(config.colorConverterOptions, electronClipboardCopier),
         new DictionaryPlugin(config.dictionaryOptions, electronClipboardCopier, getGoogleDictionaryDefinitions),
         new WeatherPlugin(config, translationSet, electronClipboardCopier),

--- a/src/renderer/settings/commandline-settings-component.ts
+++ b/src/renderer/settings/commandline-settings-component.ts
@@ -11,12 +11,14 @@ import { getCurrentOperatingSystem } from "../../common/helpers/operating-system
 import { platform } from "os";
 import { MacOsShell, WindowsShell } from "../../main/plugins/commandline-plugin/shells";
 import { OperatingSystem } from "../../common/operating-system";
+import { getFilePath } from "../dialogs";
 
 const operatingSystem = getCurrentOperatingSystem(platform());
 
 export const commandlineSettingsComponent = Vue.extend({
     data() {
         return {
+            isWindows: operatingSystem === OperatingSystem.Windows,
             availableShells: Object.values(operatingSystem === OperatingSystem.Windows ? WindowsShell : MacOsShell).map(
                 (shell) => shell.toString(),
             ),
@@ -46,6 +48,22 @@ export const commandlineSettingsComponent = Vue.extend({
         },
         updateConfig() {
             vueEventDispatcher.$emit(VueEventChannels.configUpdated, this.config);
+        },
+        selectFile() {
+            const filters: Electron.FileFilter[] = [
+                {
+                    extensions: ["exe"],
+                    name: "Search path to shell binary",
+                },
+            ];
+            getFilePath(filters)
+                .then((filePath) => {
+                    const config: UserConfigOptions = this.config;
+                    config.commandlineOptions.customShell = filePath;
+                })
+                .catch(() => {
+                    // do nothing if no file is selected
+                });
         },
     },
     mounted() {
@@ -96,7 +114,7 @@ export const commandlineSettingsComponent = Vue.extend({
                                 <div class="field is-grouped is-grouped-right">
                                     <div class="control">
                                         <div class="select">
-                                            <select v-model="config.commandlineOptions.shell" @change="updateConfig">
+                                            <select :disabled="config.commandlineOptions.isCustom" v-model="config.commandlineOptions.shell" @change="updateConfig">
                                                 <option v-for="availableShell in availableShells">{{ availableShell }}</option>
                                             </select>
                                         </div>
@@ -105,6 +123,59 @@ export const commandlineSettingsComponent = Vue.extend({
                             </div>
                         </div>
 
+                        <div v-if="isWindows" class="settings__option">
+                            <div class="settings__option-name">Custom shell</div>
+                            <div class="settings__option-content">
+                                <div class="field is-grouped is-grouped-right">
+                                    <div class="control">
+                                        <input id="customShellToggle" type="checkbox" name="customShellToggle" class="switch is-rounded is-success" checked="checked" v-model="config.commandlineOptions.isCustom" @change="updateConfig()">
+                                        <label for="customShellToggle"></label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="settings__setting-content-item box">
+                    <div class="settings__setting-content-item-title mb-2">
+                        <div class="title is-5">
+                            Path to binary
+                        </div>
+                    </div>
+                    <div class="columns">
+                        <div class="column field has-addons">
+                            <div class="control is-expanded">
+                                <input type="text" class="input" v-model="config.commandlineOptions.customShell" :disabled="!config.commandlineOptions.isCustom">
+                            </div>
+                            <div class="control">
+                                <button class="button" @click="selectFile" :disabled="!config.commandlineOptions.isCustom">
+                                    <span class="icon">
+                                        <i class="fas fa-folder"></i>
+                                    </span>
+                                </button>
+                            </div>
+                            <div class="control">
+                                <button class="button is-success" @click="updateConfig" :disabled="!config.commandlineOptions.isCustom">
+                                        <span class="icon">
+                                            <i class="fas fa-check"></i>
+                                        </span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+    
+                    <div class="settings__setting-content-item-title mb-2">
+                        <div class="title is-5">
+                            Shell flags
+                        </div>
+                    </div>
+                    <div class="columns">
+                        <div class="column field has-addons">
+                            <div class="control is-expanded">
+                                <input type="text" class="input" v-model="config.commandlineOptions.customShellFlags" @change="updateConfig" :disabled="!config.commandlineOptions.isCustom">
+                            </div>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
This PR adds support for a custom shell.

Go to command line settings to enable the feature (Windows only).

TODO:
- [ ] Translations
- [ ] MacOS support