### PR TITLE
Add functionality to queue and run multiple search result item executions

### DIFF
--- a/src/common/ipc-channels.ts
+++ b/src/common/ipc-channels.ts
@@ -2,6 +2,7 @@ export enum IpcChannels {
     search = "search",
     searchResponse = "search-response",
     execute = "execute",
+    emptyExecute = "empty-execute",
     autoComplete = "autocomplete",
     autoCompleteResponse = "autocomplete-response",
     openSearchResultLocation = "open-search-result-location",

--- a/src/common/search-result-item.ts
+++ b/src/common/search-result-item.ts
@@ -14,6 +14,11 @@ export interface SearchResultItem {
     supportsOpenLocation?: boolean;
 }
 
+export interface SearchResultItemExecution {
+    searchResultItem: SearchResultItem;
+    privileged: boolean;
+}
+
 export interface SearchResultItemViewModel extends SearchResultItem {
     active: boolean;
     id: string;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -767,6 +767,12 @@ function registerAllIpcListeners() {
         hideMainWindow();
     });
 
+    ipcMain.on(IpcChannels.emptyExecute, () => {
+        if (searchResultItemExecutionQueue.length > 0) {
+            hideMainWindow();
+        }
+    });
+
     ipcMain.on(
         IpcChannels.execute,
         (event, userInput: string, searchResultItem: SearchResultItem, privileged: boolean, queue: boolean) => {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -132,6 +132,10 @@ const app = new Vue({
             },
         );
 
+        vueEventDispatcher.$on(VueEventChannels.handleEmptyEnterPress, () => {
+            ipcRenderer.send(IpcChannels.emptyExecute);
+        });
+
         vueEventDispatcher.$on(
             VueEventChannels.handleOpenLocation,
             (searchResultItem: SearchResultItem | undefined) => {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -125,9 +125,9 @@ const app = new Vue({
 
         vueEventDispatcher.$on(
             VueEventChannels.handleExecution,
-            (userInput: string, searchResultIem: SearchResultItem | undefined, privileged: boolean) => {
+            (userInput: string, searchResultIem: SearchResultItem | undefined, privileged: boolean, queue: boolean) => {
                 if (searchResultIem !== undefined) {
-                    ipcRenderer.send(IpcChannels.execute, userInput, searchResultIem, privileged);
+                    ipcRenderer.send(IpcChannels.execute, userInput, searchResultIem, privileged, queue);
                 }
             },
         );

--- a/src/renderer/search-results-component.ts
+++ b/src/renderer/search-results-component.ts
@@ -185,13 +185,19 @@ export const searchResultsComponent = Vue.extend({
         });
         vueEventDispatcher.$on(
             VueEventChannels.enterPress,
-            (userInput: string, privileged: boolean, userConfirmed?: boolean) => {
+            (userInput: string, privileged: boolean, queue: boolean, userConfirmed?: boolean) => {
                 const activeItem: SearchResultItemViewModel = this.getActiveSearchResultItem();
                 if (activeItem && activeItem.originPluginType !== PluginType.None) {
                     if (activeItem.needsUserConfirmationBeforeExecution && !userConfirmed) {
                         vueEventDispatcher.$emit(VueEventChannels.userConfirmationRequested);
                     } else {
-                        vueEventDispatcher.$emit(VueEventChannels.handleExecution, userInput, activeItem, privileged);
+                        vueEventDispatcher.$emit(
+                            VueEventChannels.handleExecution,
+                            userInput,
+                            activeItem,
+                            privileged,
+                            queue,
+                        );
                     }
                 }
             },

--- a/src/renderer/search-results-component.ts
+++ b/src/renderer/search-results-component.ts
@@ -199,6 +199,8 @@ export const searchResultsComponent = Vue.extend({
                             queue,
                         );
                     }
+                } else if (!userInput) {
+                    vueEventDispatcher.$emit(VueEventChannels.handleEmptyEnterPress);
                 }
             },
         );

--- a/src/renderer/user-input-component.ts
+++ b/src/renderer/user-input-component.ts
@@ -61,8 +61,9 @@ export const userInputComponent = Vue.extend({
 
             if (event.key === "Enter") {
                 const privileged: boolean = event.shiftKey;
+                const queue: boolean = event.altKey;
                 const userConfirmed: boolean = this.userConfirmationDialogVisible;
-                vueEventDispatcher.$emit(VueEventChannels.enterPress, this.userInput, privileged, userConfirmed);
+                vueEventDispatcher.$emit(VueEventChannels.enterPress, this.userInput, privileged, queue, userConfirmed);
             }
 
             if (event.key === "Tab") {

--- a/src/renderer/vue-event-channels.ts
+++ b/src/renderer/vue-event-channels.ts
@@ -4,6 +4,7 @@ export enum VueEventChannels {
     openSearchResultLocationKeyPress = "open-search-result-location-key-press",
     handleOpenLocation = "handle-open-location",
     handleExecution = "handle-execution",
+    handleEmptyEnterPress = "handle-empty-enter-press",
     handleAutoCompletion = "handle-auto-completion",
     autoCompletionResponse = "auto-completion-result",
     mainWindowHasBeenHidden = "main-window-has-been-hidden",


### PR DESCRIPTION
This PR adds the ability to execute multiple search result items quickly and straight away from a single launcher window.

The motivation for adding this feature is that one might want to quickly launch multiple applications at once, without having to open ueli's window again after each execution. This could be doable by disabling the "_Hide window after execution_" and "_Hide window when focus is lost_" settings. However, the user input didn't clear itself automatically, and sometimes the applications launched would be focused, requiring the user to manually focus the ueli's window again.

So, a queue functionality was implemented by adding a new shortcut key combination "**Alt**" + "Enter", which adds a search result item to the queue instead of executing it immediately. The user input is then cleared automatically. Finally, the queued search result items are executed when the user hides the main window, which can be triggered by pressing the "Esc" key, or, by losing focus or executing a search result item, depending on the app's settings.

Example of functionality:

https://user-images.githubusercontent.com/46467428/235762488-bf206f94-2da5-48ee-be75-ad6e9e8e6e75.mp4