### PR TITLE
Change Winget Releaser job to `ubuntu-latest`

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -4,7 +4,7 @@ on:
         types: [released]
 jobs:
     publish:
-        runs-on: windows-latest
+        runs-on: ubuntu-latest
         steps:
             - uses: vedantmgoyal2009/winget-releaser@v2
               with:


### PR DESCRIPTION
Winget Releaser now supports non-Windows runners, and `ubuntu-latest` is generally faster.