### PR TITLE
Make Czech translation available to UI

### DIFF
--- a/src/common/translation/czech-translation-set.ts
+++ b/src/common/translation/czech-translation-set.ts
@@ -1,6 +1,6 @@
 import { TranslationSet } from "./translation-set";
 
-export const englishTranslationSet: TranslationSet = {
+export const czechTranslationSet: TranslationSet = {
     trayIconShow: "Zobrazit",
     trayIconSettings: "Nastavení",
     trayIconQuit: "Ukončit",

--- a/src/common/translation/translation-set-manager.ts
+++ b/src/common/translation/translation-set-manager.ts
@@ -1,3 +1,4 @@
+import { czechTranslationSet } from "./czech-translation-set";
 import { englishTranslationSet } from "./english-translation-set";
 import { finnishTranslationSet } from "./finnish-translation-set";
 import { germanTranslationSet } from "./german-translation-set";
@@ -17,6 +18,8 @@ import { ukrainianTranslationSet } from "./ukrainian-translation-set";
 
 export function getTranslationSet(language: Language): TranslationSet {
     switch (language) {
+        case Language.Czech:
+            return czechTranslationSet;
         case Language.English:
             return englishTranslationSet;
         case Language.Finnish:


### PR DESCRIPTION
Before this commit, the Czech translation set could not be returned from the translation set manager.