### PR TITLE
Fix translation plugin

### DIFF
--- a/src/main/plugins/translation-plugin/linguee-translator.ts
+++ b/src/main/plugins/translation-plugin/linguee-translator.ts
@@ -1,37 +1,20 @@
 import axios from "axios";
 
-interface WordType {
+interface Translation {
+    text: string;
     pos: string;
 }
 
-interface Translation {
-    text: string;
-    word_type: WordType;
-}
-
-interface ExactMatch {
+interface Lemma {
     translations: Translation[];
-}
-
-interface TranslationResponse {
-    exact_matches?: ExactMatch[];
 }
 
 export class LingueeTranslator {
     public static getTranslations(url: string): Promise<Translation[]> {
         return new Promise((resolve, reject) => {
             axios
-                .get(url)
-                .then((response) => {
-                    const data = response.data as TranslationResponse;
-                    let translations: Translation[] = [];
-                    if (data.exact_matches) {
-                        data.exact_matches
-                            .map((exactMatch) => exactMatch.translations)
-                            .forEach((t) => (translations = translations.concat(t)));
-                    }
-                    resolve(translations);
-                })
+                .get<Lemma[]>(url)
+                .then((response) => resolve(response.data?.flatMap((l) => l.translations) ?? []))
                 .catch((err) => reject(err));
         });
     }

--- a/src/main/plugins/translation-plugin/translation-plugin.ts
+++ b/src/main/plugins/translation-plugin/translation-plugin.ts
@@ -27,7 +27,7 @@ export class TranslationPlugin implements ExecutionPlugin {
             const textToTranslate = userInput.replace(this.config.prefix, "");
             const source = this.config.sourceLanguage;
             const target = this.config.targetLanguage;
-            const url = `https://linguee-api.herokuapp.com/api?q=${textToTranslate}&src=${source}&dst=${target}`;
+            const url = `https://linguee-api.fly.dev/api/v2/translations?query=${textToTranslate}&src=${source}&dst=${target}`;
 
             if (this.delay) {
                 clearTimeout(this.delay as number);
@@ -65,7 +65,7 @@ export class TranslationPlugin implements ExecutionPlugin {
                 .then((translations) => {
                     const result = translations.map((t): SearchResultItem => {
                         return {
-                            description: `${capitalize(t.word_type.pos)}`,
+                            description: `${capitalize(t.pos)}`,
                             executionArgument: t.text,
                             hideMainWindowAfterExecution: true,
                             icon: defaultTranslatorIcon,


### PR DESCRIPTION
This fixes #999 by updating translation plugin to use [v2 linguee api](https://linguee-api.fly.dev/docs#/default/translations_api_v2_translations_get).

Note that this is [not an official API](https://github.com/imankulov/linguee-api/discussions/39) and does not work for all words.

Works fine:
https://linguee-api.fly.dev/api/v2/translations?query=tree&src=en&dst=de

Returns Internal Server Error:
https://linguee-api.fly.dev/api/v2/translations?query=order&src=en&dst=de

So we should find a better API.