### PR TITLE
Add ueli command for opening debug log

### DIFF
--- a/src/common/error-search-result-item.ts
+++ b/src/common/error-search-result-item.ts
@@ -1,15 +1,16 @@
 import { SearchResultItem } from "./search-result-item";
 import { PluginType } from "../main/plugin-type";
 import { defaultErrorIcon } from "./icon/default-icons";
+import { UeliCommandExecutionArgument } from "../main/plugins/ueli-command-search-plugin/ueli-command-execution-argument";
 
 export function getErrorSearchResultItem(name: string, description?: string): SearchResultItem {
     return {
         description: description ? description : "",
-        executionArgument: "",
-        hideMainWindowAfterExecution: false,
+        executionArgument: UeliCommandExecutionArgument.OpenDebugLog,
+        hideMainWindowAfterExecution: true,
         icon: defaultErrorIcon,
         name,
-        originPluginType: PluginType.None,
+        originPluginType: PluginType.UeliCommandSearchPlugin,
         searchable: [],
     };
 }

--- a/src/common/translation/czech-translation-set.ts
+++ b/src/common/translation/czech-translation-set.ts
@@ -24,6 +24,8 @@ export const czechTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "Aktualizuje všechny indexy všech pluginů",
     ueliCommandReload: "Obnovit",
     ueliCommandReloadDescription: "Obnovit ueli",
+    ueliCommandOpenDebugLogDescription: "Otevřít záznamy pro ladění",
+    ueliCommandOpenDebugLog: "Záznamy pro ladění",
 
     generalErrorTitle: "Vyskytla se chyba",
     generalErrorDescription: "Další podrobnosti najdete v logu",

--- a/src/common/translation/english-translation-set.ts
+++ b/src/common/translation/english-translation-set.ts
@@ -24,9 +24,11 @@ export const englishTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "Refreshes all indexes of all plugins",
     ueliCommandReload: "Reload",
     ueliCommandReloadDescription: "Reload ueli",
+    ueliCommandOpenDebugLogDescription: "Open debug log",
+    ueliCommandOpenDebugLog: "Debug log",
 
-    generalErrorTitle: "An error occured",
-    generalErrorDescription: "Check log for more details",
+    generalErrorTitle: "An error occurred",
+    generalErrorDescription: "Press enter to open debug log file for more details",
 
     successfullyRefreshedIndexes: "Successfully refreshed indexes",
     successfullyClearedCaches: "Successfully cleared caches",
@@ -169,7 +171,7 @@ export const englishTranslationSet: TranslationSet = {
     applicationSearchSettingsInvalidFileExtensionErrorMessage: `"{{value}}" is not a valid file extension`,
     applicationSearchSettingsNotAFolderErrorMessage: `"{{value}} is not a folder"`,
     applicationSearchSettingsDoesNotExistErrorMessage: `"{{value}} does not exist"`,
-    applicationSearchSettingsFolderValidationError: `An error occured while trying to validate "{{value}}"`,
+    applicationSearchSettingsFolderValidationError: `An error occurred while trying to validate "{{value}}"`,
     applicationSearchSettingsUseNativeIcons: "Use native icons (turned off might result in better performance)",
 
     searchEngineSettings: "Search engine",

--- a/src/common/translation/finnish-translation-set.ts
+++ b/src/common/translation/finnish-translation-set.ts
@@ -24,6 +24,8 @@ export const finnishTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "Päivittää kaikkien lisäosien indeksit",
     ueliCommandReload: "Lataa uudelleen",
     ueliCommandReloadDescription: "Lataa ueli uudelleen",
+    ueliCommandOpenDebugLogDescription: "Avaa vianmääritysloki",
+    ueliCommandOpenDebugLog: "vianmääritysloki",
 
     generalErrorTitle: "Tapahtui virhe",
     generalErrorDescription: "Tarkista lisätietoja lokista",

--- a/src/common/translation/german-translation-set.ts
+++ b/src/common/translation/german-translation-set.ts
@@ -24,9 +24,11 @@ export const germanTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "Alle Indexe von allen Plugins aktualisieren",
     ueliCommandReload: "Neu laden",
     ueliCommandReloadDescription: "Ueli neu laden",
+    ueliCommandOpenDebugLogDescription: "Debug log öffnen",
+    ueliCommandOpenDebugLog: "Debug log",
 
     generalErrorTitle: "Es ist ein Fehler aufgetreten",
-    generalErrorDescription: "Überprüfe den Log für mehr Details",
+    generalErrorDescription: "Drücke Enter, um die Debug-Log-Datei für weitere Details zu öffnen",
 
     successfullyRefreshedIndexes: "Erfolgreich alle Indexe aktualisiert",
     successfullyClearedCaches: "Erfolgreich alle Zwischenspeicher gelöscht",

--- a/src/common/translation/hindi-translation-set.ts
+++ b/src/common/translation/hindi-translation-set.ts
@@ -24,6 +24,8 @@ export const hindiTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "सभी प्लगइन्स के सभी इंडेक्स को रिफ्रेश करता है",
     ueliCommandReload: "पुनर्प्रारंभ करें",
     ueliCommandReloadDescription: "उएली पुनर्प्रारंभ करें",
+    ueliCommandOpenDebugLogDescription: "डीबग लॉग खोलें",
+    ueliCommandOpenDebugLog: "लॉग को डीबग करें",
 
     generalErrorTitle: "एक त्रुटि हुई",
     generalErrorDescription: "अधिक जानकारी के लिए लॉग चेक करें",

--- a/src/common/translation/italian-translation-set.ts
+++ b/src/common/translation/italian-translation-set.ts
@@ -25,6 +25,8 @@ export const italianTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "Aggiorna tutti gli indici di tutti i plugin",
     ueliCommandReload: "Ricarica",
     ueliCommandReloadDescription: "Ricarica ueli",
+    ueliCommandOpenDebugLogDescription: "Apri log di debug",
+    ueliCommandOpenDebugLog: "Log di debug",
 
     generalErrorTitle: "Si è verificato un errore",
     generalErrorDescription: "Controlla il registro per maggiori dettagli",

--- a/src/common/translation/japanese-translation-set.ts
+++ b/src/common/translation/japanese-translation-set.ts
@@ -24,6 +24,8 @@ export const japaneseTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "全てのプラグインのインデックスを再作成",
     ueliCommandReload: "再読み込み",
     ueliCommandReloadDescription: "ueli の再読み込み",
+    ueliCommandOpenDebugLogDescription: "デバッグログを開く",
+    ueliCommandOpenDebugLog: "デバッグログ",
 
     generalErrorTitle: "エラーが発生しました",
     generalErrorDescription: "詳細はログを確認してください",

--- a/src/common/translation/korean-translation-set.ts
+++ b/src/common/translation/korean-translation-set.ts
@@ -24,6 +24,8 @@ export const koreanTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "모든 플러그인의 모든 인덱스를 갱신합니다.",
     ueliCommandReload: "다시 로드",
     ueliCommandReloadDescription: "ueli 다시 로드",
+    ueliCommandOpenDebugLogDescription: "디버그 로그 열기",
+    ueliCommandOpenDebugLog: "디버그 로그",
 
     generalErrorTitle: "오류가 발생하였습니다",
     generalErrorDescription: "로그에서 더 많은 정보를 확인하세요.",

--- a/src/common/translation/portuguese-translation-set.ts
+++ b/src/common/translation/portuguese-translation-set.ts
@@ -24,6 +24,8 @@ export const portugueseTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "Atualizar os índices de todos os plugins",
     ueliCommandReload: "Recarregar",
     ueliCommandReloadDescription: "Recarregar ueli",
+    ueliCommandOpenDebugLogDescription: "Abrir o log de debug",
+    ueliCommandOpenDebugLog: "Log de debug",
 
     generalErrorTitle: "Um erro ocorreu",
     generalErrorDescription: "Verificar log para mais detalhes",

--- a/src/common/translation/russian-translation-set.ts
+++ b/src/common/translation/russian-translation-set.ts
@@ -24,6 +24,8 @@ export const russianTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "Обновить индексы всех плагинов",
     ueliCommandReload: "Перезагрузить",
     ueliCommandReloadDescription: "Перезагрузить ueli",
+    ueliCommandOpenDebugLogDescription: "Открыть лог отладки",
+    ueliCommandOpenDebugLog: "Лог отладки",
 
     generalErrorTitle: "Что-то пошло не так",
     generalErrorDescription: "Проверьте логи для получения более подробной информации",

--- a/src/common/translation/simplified-chinese-translation-set.ts
+++ b/src/common/translation/simplified-chinese-translation-set.ts
@@ -24,6 +24,8 @@ export const simplifiedChineseTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "刷新所有插件的全部缓存",
     ueliCommandReload: "重载",
     ueliCommandReloadDescription: "重新加载 ueli",
+    ueliCommandOpenDebugLogDescription: "打开调试日志",
+    ueliCommandOpenDebugLog: "调试日志",
 
     generalErrorTitle: "发生错误",
     generalErrorDescription: "查看日志文件",

--- a/src/common/translation/spanish-translation-set.ts
+++ b/src/common/translation/spanish-translation-set.ts
@@ -24,6 +24,8 @@ export const spanishTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "Refrescar todos los índices de todos los plugins",
     ueliCommandReload: "Recargar",
     ueliCommandReloadDescription: "Recargar ueli",
+    ueliCommandOpenDebugLogDescription: "Abrir log de depuración",
+    ueliCommandOpenDebugLog: "Log de depuración",
 
     generalErrorTitle: "Ha ocurrido un error",
     generalErrorDescription: "Revisa el log para más detalles",

--- a/src/common/translation/traditional-chinese-translation-set.ts
+++ b/src/common/translation/traditional-chinese-translation-set.ts
@@ -24,6 +24,8 @@ export const traditionalChineseTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "重新整理所有外掛程式的所有快取",
     ueliCommandReload: "重新載入",
     ueliCommandReloadDescription: "重新載入 ueli",
+    ueliCommandOpenDebugLogDescription: "打開除錯日誌",
+    ueliCommandOpenDebugLog: "调试协议",
 
     generalErrorTitle: "發生錯誤",
     generalErrorDescription: "查看日誌檔案",

--- a/src/common/translation/translation-set.ts
+++ b/src/common/translation/translation-set.ts
@@ -22,6 +22,8 @@ export interface TranslationSet {
     ueliCommandRefreshIndexes: string;
     ueliCommandClearCachesDescription: string;
     ueliCommandClearCaches: string;
+    ueliCommandOpenDebugLogDescription: string;
+    ueliCommandOpenDebugLog: string;
 
     generalErrorTitle: string;
     generalErrorDescription: string;

--- a/src/common/translation/turkish-translation-set.ts
+++ b/src/common/translation/turkish-translation-set.ts
@@ -24,6 +24,8 @@ export const turkishTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "Tüm eklentilerin tüm dizinlerini yeniler",
     ueliCommandReload: "Yeniden başlat",
     ueliCommandReloadDescription: "Ueli'yi yeniden başlat",
+    ueliCommandOpenDebugLogDescription: "Hata ayıklama günlüğünü aç",
+    ueliCommandOpenDebugLog: "Hata ayıklama günlüğü",
 
     generalErrorTitle: "Bir hata oluştu",
     generalErrorDescription: "Daha fazla ayrıntı için günlüğü kontrol edin",

--- a/src/common/translation/ukrainian-translation-set.ts
+++ b/src/common/translation/ukrainian-translation-set.ts
@@ -24,6 +24,8 @@ export const ukrainianTranslationSet: TranslationSet = {
     ueliCommandRefreshIndexesDescription: "Оновити індекси всіх плагінів",
     ueliCommandReload: "Перезавантажити",
     ueliCommandReloadDescription: "Перезавантажити ueli",
+    ueliCommandOpenDebugLogDescription: "Відкрити лог налагодження",
+    ueliCommandOpenDebugLog: "Лог налагодження",
 
     generalErrorTitle: "Щось пішло не так",
     generalErrorDescription: "Перевірте логи для отримання більшої інформації",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -687,14 +687,14 @@ function updateSearchResults(results: SearchResultItem[], webcontents: WebConten
     webcontents.send(IpcChannels.searchResponse, results);
 }
 
-function noSearchResultsFound() {
+function showErrorSearchResultItem() {
     if (windowExists(mainWindow)) {
         updateMainWindowSize(1, config.appearanceOptions);
-        const noResultFound = getErrorSearchResultItem(
+        const errorSearchResultItem = getErrorSearchResultItem(
             translationSet.generalErrorTitle,
             translationSet.generalErrorDescription,
         );
-        mainWindow.webContents.send(IpcChannels.searchResponse, [noResultFound]);
+        mainWindow.webContents.send(IpcChannels.searchResponse, [errorSearchResultItem]);
     }
 }
 
@@ -732,7 +732,7 @@ function registerAllIpcListeners() {
             })
             .catch((err) => {
                 logger.error(err);
-                noSearchResultsFound();
+                showErrorSearchResultItem();
             });
     });
 
@@ -742,7 +742,7 @@ function registerAllIpcListeners() {
             .then((result) => updateSearchResults(result, event.sender))
             .catch((err) => {
                 logger.error(err);
-                noSearchResultsFound();
+                showErrorSearchResultItem();
             });
     });
 
@@ -777,7 +777,7 @@ function registerAllIpcListeners() {
             .then(() => hideMainWindow())
             .catch((err) => {
                 logger.error(err);
-                noSearchResultsFound();
+                showErrorSearchResultItem();
             });
     });
 
@@ -825,9 +825,6 @@ function registerAllIpcListeners() {
     ipcMain.on(IpcChannels.openDebugLogRequested, () => {
         logger
             .openLog()
-            .then(() => {
-                /* do nothing */
-            })
             .catch((err) => notifyRenderer(err, NotificationType.Error));
     });
 
@@ -864,6 +861,9 @@ function registerAllIpcListeners() {
                 break;
             case UeliCommandExecutionArgument.ClearCaches:
                 clearAllCaches();
+                break;
+            case UeliCommandExecutionArgument.OpenDebugLog:
+                ipcMain.emit(IpcChannels.openDebugLogRequested);
                 break;
             default:
                 logger.error("Unhandled ueli command execution");

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -823,9 +823,7 @@ function registerAllIpcListeners() {
     });
 
     ipcMain.on(IpcChannels.openDebugLogRequested, () => {
-        logger
-            .openLog()
-            .catch((err) => notifyRenderer(err, NotificationType.Error));
+        logger.openLog().catch((err) => notifyRenderer(err, NotificationType.Error));
     });
 
     ipcMain.on(IpcChannels.openTempFolderRequested, () => {

--- a/src/main/plugins/ueli-command-search-plugin/ueli-command-execution-argument.ts
+++ b/src/main/plugins/ueli-command-search-plugin/ueli-command-execution-argument.ts
@@ -5,4 +5,5 @@ export enum UeliCommandExecutionArgument {
     OpenSettings = "open-settings",
     RefreshIndexes = "refresh-indexes",
     ClearCaches = "clear-caches",
+    OpenDebugLog = "open-debug-log",
 }

--- a/src/main/plugins/ueli-command-search-plugin/ueli-command-search-plugin.ts
+++ b/src/main/plugins/ueli-command-search-plugin/ueli-command-search-plugin.ts
@@ -123,6 +123,12 @@ export class UeliCommandSearchPlugin implements SearchPlugin {
                 hideMainWindowAfterExecution: false,
                 name: this.translationSet.ueliCommandClearCaches,
             },
+            {
+                description: this.translationSet.ueliCommandOpenDebugLogDescription,
+                executionArgument: UeliCommandExecutionArgument.OpenDebugLog,
+                hideMainWindowAfterExecution: true,
+                name: this.translationSet.ueliCommandOpenDebugLog,
+            },
         ];
     }
 }


### PR DESCRIPTION
This adds an ueli command for opening the debug log file:

![grafik](https://github.com/oliverschwendener/ueli/assets/6824291/41476a11-5a07-4c55-b854-a9ea3a54cff2)

Additionally this command is now used for the general error search result and thereby fixes #348:

![grafik](https://github.com/oliverschwendener/ueli/assets/6824291/1633deb1-c2c4-4a2b-b09f-562060ea43e2)

I only updated German and English versions of the generalErrorDescription, the rest still needs to be updated.