### PR TITLE
Feature: Configurable IniFileParser

### DIFF
--- a/src/main/Core/IniFileParser/IniFileParser.test.ts
+++ b/src/main/Core/IniFileParser/IniFileParser.test.ts
@@ -30,4 +30,37 @@ datadir = /var/lib/data
             },
         });
     });
+
+    it("should parse an ini file with a different comment delimiter and inline comments", () => {
+        const iniFileString = `
+# This comment is being ignored
+scope = global
+notcomment = this;is;not;a;comment
+iscomment = value#an inline comment
+
+[database]
+user = dbuser
+password = dbpassword
+database = use_this_database
+
+[paths.default]
+datadir = /var/lib/data
+        `;
+
+        expect(new IniFileParser().parseIniFileContent(iniFileString.trim())).toEqual({
+            "": {
+                scope: "global",
+                notcomment: "this;is;not;a;comment",
+                iscomment: "value",
+            },
+            database: {
+                database: "use_this_database",
+                password: "dbpassword",
+                user: "dbuser",
+            },
+            "paths.default": {
+                datadir: "/var/lib/data",
+            },
+        });
+    });
 });

--- a/src/main/Core/IniFileParser/IniFileParser.test.ts
+++ b/src/main/Core/IniFileParser/IniFileParser.test.ts
@@ -4,8 +4,9 @@ import { IniFileParser } from "./IniFileParser";
 describe(IniFileParser, () => {
     it("should parse an ini file", () => {
         const iniFileString = `
-# This comment is being ignored
+; This comment is being ignored
 scope = global
+comments = no;inline;comments
 
 [database]
 user = dbuser
@@ -19,6 +20,7 @@ datadir = /var/lib/data
         expect(new IniFileParser().parseIniFileContent(iniFileString.trim())).toEqual({
             "": {
                 scope: "global",
+                comments: "no;inline;comments",
             },
             database: {
                 user: "dbuser",
@@ -47,7 +49,7 @@ database = use_this_database
 datadir = /var/lib/data
         `;
 
-        expect(new IniFileParser().parseIniFileContent(iniFileString.trim())).toEqual({
+        expect(new IniFileParser().parseIniFileContent(iniFileString.trim(), "#", true)).toEqual({
             "": {
                 scope: "global",
                 notcomment: "this;is;not;a;comment",

--- a/src/main/Core/IniFileParser/IniFileParser.ts
+++ b/src/main/Core/IniFileParser/IniFileParser.ts
@@ -4,14 +4,17 @@ export class IniFileParser implements IniFileParserInterface {
     // Defaults to ';' as comment
     public parseIniFileContent(
         fileString: string,
-        commentDelimiter: string = ';',
+        commentDelimiter: string = ";",
         allowInlineComments?: boolean,
     ): Record<string, Record<string, string>> {
         let fileLines = fileString.split("\n");
 
         fileLines = fileLines.filter((line) => !line.startsWith(commentDelimiter) && line.trim() !== "");
         if (allowInlineComments) {
-            fileLines = fileLines.map((line) => line.slice(0, line.indexOf(commentDelimiter)));
+            fileLines = fileLines.map((line) => {
+                const index = line.indexOf(commentDelimiter);
+                return index >= 0 ? line.slice(0, line.indexOf(commentDelimiter)) : line;
+            });
         }
 
         const entries: Record<string, Record<string, string>> = {};
@@ -25,7 +28,7 @@ export class IniFileParser implements IniFileParserInterface {
                 entries[group] = {};
             } else {
                 // Entry
-                const [key, ...entrySplit] = line.split("=");
+                const [key, ...entrySplit] = line.split("=").map((text) => text.trim());
                 const entry = entrySplit.join("=");
                 if (entries[group][key]) throw `Ini Format Error! Duplicate key in ${group} in file ${fileString}`;
                 entries[group][key] = entry;

--- a/src/main/Core/IniFileParser/IniFileParser.ts
+++ b/src/main/Core/IniFileParser/IniFileParser.ts
@@ -1,35 +1,34 @@
 import { IniFileParser as IniFileParserInterface } from "./Contract";
 
 export class IniFileParser implements IniFileParserInterface {
-    public parseIniFileContent(fileString: string): Record<string, unknown> {
-        const fileContent = fileString.split("\n").filter((v) => !v.startsWith("#") && v !== "");
+    // Defaults to ';' as comment
+    public parseIniFileContent(
+        fileString: string,
+        commentDelimiter: string = ';',
+        allowInlineComments?: boolean,
+    ): Record<string, Record<string, string>> {
+        let fileLines = fileString.split("\n");
+
+        fileLines = fileLines.filter((line) => !line.startsWith(commentDelimiter) && line.trim() !== "");
+        if (allowInlineComments) {
+            fileLines = fileLines.map((line) => line.slice(0, line.indexOf(commentDelimiter)));
+        }
+
         const entries: Record<string, Record<string, string>> = {};
         let group = "";
         entries[group] = {};
-        for (const line of fileContent) {
-            // Comments
-            if (line.startsWith("#") || line.trim() === "") {
-                continue;
-            }
-
+        for (const line of fileLines) {
             // New group
             if (line.startsWith("[") && line.endsWith("]") && !line.slice(1, -1).match(/\[\]/m)) {
-                if (entries[line]) {
-                    throw `Ini Format Error! Duplicate groups found in ${fileString}`;
-                }
-
+                if (entries[line]) throw `Ini Format Error! Duplicate groups found in ${fileString}`;
                 group = line.slice(1, -1);
                 entries[group] = {};
             } else {
                 // Entry
                 const [key, ...entrySplit] = line.split("=");
                 const entry = entrySplit.join("=");
-
-                if (entries[group][key.trim()]) {
-                    throw `Ini Format Error! Duplicate key in ${group} in file ${fileString}`;
-                }
-
-                entries[group][key.trim()] = entry.trim();
+                if (entries[group][key]) throw `Ini Format Error! Duplicate key in ${group} in file ${fileString}`;
+                entries[group][key] = entry;
             }
         }
         return entries;


### PR DESCRIPTION
Added options to IniFileParser to make it usable for other `.ini` dialects outside of Unix. 

';' used for default comments as it seems to be the most common