### PR TITLE
Added test to cover `\r\n` line endings

### DIFF
--- a/src/main/Core/IniFileParser/IniFileParser.test.ts
+++ b/src/main/Core/IniFileParser/IniFileParser.test.ts
@@ -65,4 +65,27 @@ datadir = /var/lib/data
             },
         });
     });
+
+    it("should be able to handle \r\n line endings", () => {
+        const iniFileString =
+            "[Profile1]\r\nName=default\r\nIsRelative=1\r\nPath=Profiles/f0u1l8pa.default\r\nDefault=1\r\n\r\n" +
+            "[Profile0]\r\nName=default-release\r\nIsRelative=1\r\nPath=Profiles/0p40tli3.default-release";
+
+        const iniFileContent = new IniFileParser().parseIniFileContent(iniFileString.trim());
+
+        expect(iniFileContent).toEqual({
+            "": {},
+            Profile1: {
+                Name: "default",
+                IsRelative: "1",
+                Path: "Profiles/f0u1l8pa.default",
+                Default: "1",
+            },
+            Profile0: {
+                Name: "default-release",
+                IsRelative: "1",
+                Path: "Profiles/0p40tli3.default-release",
+            },
+        });
+    });
 });

--- a/src/main/Core/IniFileParser/IniFileParser.ts
+++ b/src/main/Core/IniFileParser/IniFileParser.ts
@@ -7,7 +7,7 @@ export class IniFileParser implements IniFileParserInterface {
         commentDelimiter: string = ";",
         allowInlineComments?: boolean,
     ): Record<string, Record<string, string>> {
-        let fileLines = fileString.split("\n");
+        let fileLines = fileString.split(/(\r\n|\r|\n)/);
 
         fileLines = fileLines.filter((line) => !line.startsWith(commentDelimiter) && line.trim() !== "");
         if (allowInlineComments) {


### PR DESCRIPTION
This PR should add a fix to the IniFileParser in order to handle `\r\n` line endings correctly.