### PR TITLE
Fix encoding issues in application search

### DIFF
--- a/src/main/Core/FileSystemUtility/NodeJsFileSystemUtility.ts
+++ b/src/main/Core/FileSystemUtility/NodeJsFileSystemUtility.ts
@@ -16,6 +16,8 @@ import { join } from "path";
 import type { FileSystemUtility } from "./Contract";
 
 export class NodeJsFileSystemUtility implements FileSystemUtility {
+    private byteOrderMark: string = "\ufeff";
+
     public async clearFolder(folderPath: string): Promise<void> {
         const filePaths = await this.readDirectory(folderPath);
         await Promise.all(filePaths.map((filePath) => this.removeFile(filePath)));
@@ -60,7 +62,7 @@ export class NodeJsFileSystemUtility implements FileSystemUtility {
 
     public writeTextFile(data: string, filePath: string): Promise<void> {
         return new Promise((resolve, reject) => {
-            writeFile(filePath, data, "utf-8", (error) => {
+            writeFile(filePath, `${this.byteOrderMark}${data}`, "utf-8", (error) => {
                 error ? reject(error) : resolve();
             });
         });

--- a/src/main/Core/ImageGenerator/Windows/WindowsApplicationIconExtractor.ts
+++ b/src/main/Core/ImageGenerator/Windows/WindowsApplicationIconExtractor.ts
@@ -86,7 +86,7 @@ export class WindowsApplicationIconExtractor implements FileIconExtractor {
     }
 
     private getPowershellCommand(inFilePath: string, outFilePath: string): string {
-        return `Get-Associated-Icon -InFilePath "${inFilePath}" -OutFilePath "${outFilePath}"`;
+        return `Get-Associated-Icon -InFilePath '${inFilePath}' -OutFilePath '${outFilePath}'`;
     }
 
     private getCacheFilePaths(filePaths: string[]): Record<string, string> {

--- a/src/main/Core/ImageGenerator/Windows/powershellScripts.ts
+++ b/src/main/Core/ImageGenerator/Windows/powershellScripts.ts
@@ -30,15 +30,9 @@ function Get-Associated-Icon {
         $InFilePath = Get-Shortcut-Target -ShortcutFilePath $InFilePath
     }
 
-    # ExtractAssociatedIcon will crash if the file path contains special characters
-    # e.g. "Über iTunes" will crash the script and thus no search results are shown
-    try {
-        $Icon = [System.Drawing.Icon]::ExtractAssociatedIcon($InFilePath)
+    $Icon = [System.Drawing.Icon]::ExtractAssociatedIcon($InFilePath)
 
-        if ($null -ne $Icon) {
-            $Icon.ToBitmap().Save($OutFilePath, [System.Drawing.Imaging.ImageFormat]::Png)
-        }
-    } catch {
-        # Do nothing and continue
+    if ($null -ne $Icon) {
+        $Icon.ToBitmap().Save($OutFilePath, [System.Drawing.Imaging.ImageFormat]::Png)
     }
 }`;

--- a/src/main/Extensions/ApplicationSearch/Windows/WindowsApplicationRepository.ts
+++ b/src/main/Extensions/ApplicationSearch/Windows/WindowsApplicationRepository.ts
@@ -83,8 +83,8 @@ export class WindowsApplicationRepository implements ApplicationRepository {
         const { getWindowsAppsPowershellScript } = usePowershellScripts();
 
         return `
+            [Console]::OutputEncoding = [System.Text.Encoding]::UTF8;
             ${getWindowsAppsPowershellScript}
-
             Get-WindowsApps -FolderPaths ${concatenatedFolderPaths} -FileExtensions ${concatenatedFileExtensions};`;
     }
 

--- a/src/main/Extensions/ApplicationSearch/Windows/usePowershellScripts.ts
+++ b/src/main/Extensions/ApplicationSearch/Windows/usePowershellScripts.ts
@@ -10,7 +10,7 @@ const getWindowsAppsPowershellScript = `
 
 const getWindowsStoreApps = `
     $ErrorActionPreference = 'SilentlyContinue';
-    [System.Console]::OutputEncoding = [System.Text.Encoding]::UTF8;
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8;
 
     filter ArrayToHash
     {


### PR DESCRIPTION
Same topic as #1096 but it now should work correctly by using correct encoding everywhere.

![grafik](https://github.com/oliverschwendener/ueli/assets/6824291/5ca4a64a-701f-4dcc-adda-d7207bf6f557)