### PR TITLE
fix: Use "kl" instead of "lk" as DuckDuckGo parameter

### DIFF
--- a/src/main/Extensions/WebSearch/DuckDuckGoWebSearchEngine.test.ts
+++ b/src/main/Extensions/WebSearch/DuckDuckGoWebSearchEngine.test.ts
@@ -12,8 +12,8 @@ describe(DuckDuckGoWebSearchEngine, () => {
             const net = <Net>{ fetch: (url) => fetchMock(url) };
 
             expect(await new DuckDuckGoWebSearchEngine(net).getSuggestions("test", "en-US")).toEqual([
-                { text: "test1", url: "https://duckduckgo.com/?q=test1&lk=us-en" },
-                { text: "test2", url: "https://duckduckgo.com/?q=test2&lk=us-en" },
+                { text: "test1", url: "https://duckduckgo.com/?q=test1&kl=us-en" },
+                { text: "test2", url: "https://duckduckgo.com/?q=test2&kl=us-en" },
             ]);
         });
     });
@@ -21,13 +21,13 @@ describe(DuckDuckGoWebSearchEngine, () => {
     describe(DuckDuckGoWebSearchEngine.prototype.getSearchUrl, () => {
         it("should return the search URL", () => {
             expect(new DuckDuckGoWebSearchEngine(<Net>{}).getSearchUrl("test", "en-US")).toBe(
-                "https://duckduckgo.com/?q=test&lk=us-en",
+                "https://duckduckgo.com/?q=test&kl=us-en",
             );
         });
 
         it("should return the search URL with default language when the given locale is not supported", () => {
             expect(new DuckDuckGoWebSearchEngine(<Net>{}).getSearchUrl("test", "de-DE")).toBe(
-                "https://duckduckgo.com/?q=test&lk=us-en",
+                "https://duckduckgo.com/?q=test&kl=us-en",
             );
         });
     });

--- a/src/main/Extensions/WebSearch/DuckDuckGoWebSearchEngine.ts
+++ b/src/main/Extensions/WebSearch/DuckDuckGoWebSearchEngine.ts
@@ -25,7 +25,7 @@ export class DuckDuckGoWebSearchEngine implements WebSearchEngine {
     }
 
     public getSearchUrl(searchTerm: string, locale: string): string {
-        return `https://duckduckgo.com/?q=${encodeURIComponent(searchTerm)}&lk=${this.getLocaleString(locale)}`;
+        return `https://duckduckgo.com/?q=${encodeURIComponent(searchTerm)}&kl=${this.getLocaleString(locale)}`;
     }
 
     public getImageFileName(): string {


### PR DESCRIPTION
DuckDuckGo's region parameter is supposed to be “kl”. 🧐
cf: https://duckduckgo.com/duckduckgo-help-pages/settings/params/
