### PR TITLE
feat: added linux desktop environment resolver

### DIFF
--- a/src/common/Core/LinuxDesktopEnvironment.ts
+++ b/src/common/Core/LinuxDesktopEnvironment.ts
@@ -1,4 +1,0 @@
-/**
- * A list of Linux desktop environments.
- */
-export type LinuxDesktopEnvironment = "GNOME" | "GNOME-Classic"; // add more desktop environments here

--- a/src/common/Core/LinuxDesktopEnvironment.ts
+++ b/src/common/Core/LinuxDesktopEnvironment.ts
@@ -1,0 +1,4 @@
+/**
+ * A list of Linux desktop environments.
+ */
+export type LinuxDesktopEnvironment = "GNOME" | "GNOME-Classic"; // add more desktop environments here

--- a/src/main/Core/Dependencies.ts
+++ b/src/main/Core/Dependencies.ts
@@ -25,6 +25,7 @@ export type Dependencies = {
     GlobalShortcut?: Electron.GlobalShortcut;
     IniFileParser?: Core.IniFileParser;
     IpcMain?: Electron.IpcMain;
+    LinuxDesktopEnvironmentResolver?: Core.LinuxDesktopEnvironmentResolver;
     Logger?: Core.Logger;
     NativeTheme?: Electron.NativeTheme;
     Net?: Electron.Net;

--- a/src/main/Core/LinuxDesktopEnvironment/Contract/LinuxDesktopEnvironment.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/Contract/LinuxDesktopEnvironment.ts
@@ -1,0 +1,4 @@
+/**
+ * A list of known Linux desktop environments.
+ */
+export type LinuxDesktopEnvironment = "GNOME" | "KDE";

--- a/src/main/Core/LinuxDesktopEnvironment/Contract/LinuxDesktopEnvironmentResolver.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/Contract/LinuxDesktopEnvironmentResolver.ts
@@ -1,0 +1,13 @@
+import type { LinuxDesktopEnvironment } from "@common/Core/LinuxDesktopEnvironment";
+
+/**
+ * A utility to resolve the current Linux desktop environment.
+ */
+export interface LinuxDesktopEnvironmentResolver {
+    /**
+     * Resolves the current Linux desktop environment.
+     *
+     * @returns The current Linux desktop environment or undefined if it could not be resolved.
+     */
+    resolve(): LinuxDesktopEnvironment | undefined;
+}

--- a/src/main/Core/LinuxDesktopEnvironment/Contract/LinuxDesktopEnvironmentResolver.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/Contract/LinuxDesktopEnvironmentResolver.ts
@@ -1,3 +1,5 @@
+import type { LinuxDesktopEnvironment } from "./LinuxDesktopEnvironment";
+
 /**
  * A utility to resolve the current Linux desktop environment.
  */
@@ -7,5 +9,5 @@ export interface LinuxDesktopEnvironmentResolver {
      *
      * @returns The current Linux desktop environment or undefined if it could not be resolved.
      */
-    resolve(): string | undefined;
+    resolve(): LinuxDesktopEnvironment | undefined;
 }

--- a/src/main/Core/LinuxDesktopEnvironment/Contract/LinuxDesktopEnvironmentResolver.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/Contract/LinuxDesktopEnvironmentResolver.ts
@@ -1,5 +1,3 @@
-import type { LinuxDesktopEnvironment } from "@common/Core/LinuxDesktopEnvironment";
-
 /**
  * A utility to resolve the current Linux desktop environment.
  */
@@ -9,5 +7,5 @@ export interface LinuxDesktopEnvironmentResolver {
      *
      * @returns The current Linux desktop environment or undefined if it could not be resolved.
      */
-    resolve(): LinuxDesktopEnvironment | undefined;
+    resolve(): string | undefined;
 }

--- a/src/main/Core/LinuxDesktopEnvironment/Contract/index.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/Contract/index.ts
@@ -1,0 +1,1 @@
+export * from "./LinuxDesktopEnvironmentResolver";

--- a/src/main/Core/LinuxDesktopEnvironment/Contract/index.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/Contract/index.ts
@@ -1,1 +1,2 @@
+export * from "./LinuxDesktopEnvironment";
 export * from "./LinuxDesktopEnvironmentResolver";

--- a/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentModule.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentModule.ts
@@ -1,0 +1,12 @@
+import type { Dependencies } from "@Core/Dependencies";
+import type { DependencyRegistry } from "@Core/DependencyRegistry";
+import { LinuxDesktopEnvironmentResolver } from "./LinuxDesktopEnvironmentResolver";
+
+export class LinuxDesktopEnvironmentModule {
+    public static bootstrap(dependencyRegistry: DependencyRegistry<Dependencies>): void {
+        dependencyRegistry.register(
+            "LinuxDesktopEnvironmentResolver",
+            new LinuxDesktopEnvironmentResolver(dependencyRegistry.get("EnvironmentVariableProvider")),
+        );
+    }
+}

--- a/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.test.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.test.ts
@@ -1,9 +1,16 @@
 import type { EnvironmentVariableProvider } from "@Core/EnvironmentVariableProvider";
 import { describe, expect, it, vi } from "vitest";
+import type { LinuxDesktopEnvironment } from "./Contract";
 import { LinuxDesktopEnvironmentResolver } from "./LinuxDesktopEnvironmentResolver";
 
 describe(LinuxDesktopEnvironmentResolver, () => {
-    const testResolve = ({ expected, xdgCurrentDesktop }: { expected?: string; xdgCurrentDesktop: string }) => {
+    const testResolve = ({
+        expected,
+        xdgCurrentDesktop,
+    }: {
+        expected?: LinuxDesktopEnvironment;
+        xdgCurrentDesktop: string;
+    }) => {
         const getMock = vi.fn().mockReturnValue(xdgCurrentDesktop);
         const environmentVariableProvider = <EnvironmentVariableProvider>{ get: (n) => getMock(n) };
 

--- a/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.test.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.test.ts
@@ -1,0 +1,6 @@
+import { describe } from "vitest";
+import { LinuxDesktopEnvironmentResolver } from "./LinuxDesktopEnvironmentResolver";
+
+describe(LinuxDesktopEnvironmentResolver, () => {
+    // Add tests here
+});

--- a/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.test.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.test.ts
@@ -1,6 +1,23 @@
-import { describe } from "vitest";
+import type { EnvironmentVariableProvider } from "@Core/EnvironmentVariableProvider";
+import { describe, expect, it, vi } from "vitest";
 import { LinuxDesktopEnvironmentResolver } from "./LinuxDesktopEnvironmentResolver";
 
 describe(LinuxDesktopEnvironmentResolver, () => {
-    // Add tests here
+    const testResolve = ({ expected, xdgCurrentDesktop }: { expected?: string; xdgCurrentDesktop: string }) => {
+        const getMock = vi.fn().mockReturnValue(xdgCurrentDesktop);
+        const environmentVariableProvider = <EnvironmentVariableProvider>{ get: (n) => getMock(n) };
+
+        expect(new LinuxDesktopEnvironmentResolver(environmentVariableProvider).resolve()).toBe(expected);
+        expect(getMock).toHaveBeenCalledOnce();
+        expect(getMock).toHaveBeenCalledWith("XDG_CURRENT_DESKTOP");
+    };
+
+    it("should return undefined when XDG_CURRENT_DESKTOP environment variable is not set", () =>
+        testResolve({ expected: undefined, xdgCurrentDesktop: "" }));
+
+    it("should return GNOME when XDG_CURRENT_DESKTOP is ubuntu:GNOME", () =>
+        testResolve({ expected: "GNOME", xdgCurrentDesktop: "ubuntu:GNOME" }));
+
+    it("should return KDE when XDG_CURRENT_DESKTOP is KDE", () =>
+        testResolve({ expected: "KDE", xdgCurrentDesktop: "KDE" }));
 });

--- a/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.ts
@@ -1,0 +1,12 @@
+import type { LinuxDesktopEnvironment } from "@common/Core/LinuxDesktopEnvironment";
+import type { EnvironmentVariableProvider } from "@Core/EnvironmentVariableProvider";
+import type { LinuxDesktopEnvironmentResolver as LinuxDesktopEnvironmentResolverInterface } from "./Contract";
+
+export class LinuxDesktopEnvironmentResolver implements LinuxDesktopEnvironmentResolverInterface {
+    public constructor(private readonly environmentVariableProvider: EnvironmentVariableProvider) {}
+
+    public resolve(): LinuxDesktopEnvironment | undefined {
+        // Add implementation here
+        throw new Error("Method not implemented.");
+    }
+}

--- a/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.ts
@@ -1,15 +1,18 @@
 import type { EnvironmentVariableProvider } from "@Core/EnvironmentVariableProvider";
-import type { LinuxDesktopEnvironmentResolver as LinuxDesktopEnvironmentResolverInterface } from "./Contract";
+import type {
+    LinuxDesktopEnvironment,
+    LinuxDesktopEnvironmentResolver as LinuxDesktopEnvironmentResolverInterface,
+} from "./Contract";
 
 export class LinuxDesktopEnvironmentResolver implements LinuxDesktopEnvironmentResolverInterface {
     public constructor(private readonly environmentVariableProvider: EnvironmentVariableProvider) {}
 
-    public resolve(): string | undefined {
+    public resolve(): LinuxDesktopEnvironment | undefined {
         const map: Record<string, string> = {
             "ubuntu:GNOME": "GNOME",
             KDE: "KDE",
         };
 
-        return map[this.environmentVariableProvider.get("XDG_CURRENT_DESKTOP")];
+        return map[this.environmentVariableProvider.get("XDG_CURRENT_DESKTOP")] as LinuxDesktopEnvironment | undefined;
     }
 }

--- a/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.ts
@@ -5,13 +5,11 @@ export class LinuxDesktopEnvironmentResolver implements LinuxDesktopEnvironmentR
     public constructor(private readonly environmentVariableProvider: EnvironmentVariableProvider) {}
 
     public resolve(): string | undefined {
-        const desktopSession = this.environmentVariableProvider.get("XDG_CURRENT_DESKTOP");
-
         const map: Record<string, string> = {
             "ubuntu:GNOME": "GNOME",
             KDE: "KDE",
         };
 
-        return map[desktopSession];
+        return map[this.environmentVariableProvider.get("XDG_CURRENT_DESKTOP")];
     }
 }

--- a/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.ts
@@ -12,6 +12,6 @@ export class LinuxDesktopEnvironmentResolver implements LinuxDesktopEnvironmentR
             KDE: "KDE",
         };
 
-        return map[desktopSession] ?? undefined;
+        return map[desktopSession];
     }
 }

--- a/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/LinuxDesktopEnvironmentResolver.ts
@@ -1,12 +1,17 @@
-import type { LinuxDesktopEnvironment } from "@common/Core/LinuxDesktopEnvironment";
 import type { EnvironmentVariableProvider } from "@Core/EnvironmentVariableProvider";
 import type { LinuxDesktopEnvironmentResolver as LinuxDesktopEnvironmentResolverInterface } from "./Contract";
 
 export class LinuxDesktopEnvironmentResolver implements LinuxDesktopEnvironmentResolverInterface {
     public constructor(private readonly environmentVariableProvider: EnvironmentVariableProvider) {}
 
-    public resolve(): LinuxDesktopEnvironment | undefined {
-        // Add implementation here
-        throw new Error("Method not implemented.");
+    public resolve(): string | undefined {
+        const desktopSession = this.environmentVariableProvider.get("XDG_CURRENT_DESKTOP");
+
+        const map: Record<string, string> = {
+            "ubuntu:GNOME": "GNOME",
+            KDE: "KDE",
+        };
+
+        return map[desktopSession] ?? undefined;
     }
 }

--- a/src/main/Core/LinuxDesktopEnvironment/index.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/index.ts
@@ -1,0 +1,1 @@
+export * from "./Contract";

--- a/src/main/Core/LinuxDesktopEnvironment/index.ts
+++ b/src/main/Core/LinuxDesktopEnvironment/index.ts
@@ -1,1 +1,2 @@
 export * from "./Contract";
+export * from "./LinuxDesktopEnvironmentModule";

--- a/src/main/Core/index.ts
+++ b/src/main/Core/index.ts
@@ -25,6 +25,7 @@ export * from "./FileSystemUtility";
 export * from "./GlobalShortcut";
 export * from "./ImageGenerator";
 export * from "./IniFileParser";
+export * from "./LinuxDesktopEnvironment";
 export * from "./Logger";
 export * from "./NativeTheme";
 export * from "./OperatingSystem";

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,6 +32,7 @@ import * as Extensions from "./Extensions";
     Core.CommandlineSwitchModule.bootstrap(dependencyRegistry);
     Core.TaskSchedulerModule.bootstrap(dependencyRegistry);
     Core.EnvironmentVariableProviderModule.bootstrap(dependencyRegistry);
+    Core.LinuxDesktopEnvironmentModule.bootstrap(dependencyRegistry);
     Core.IniFileParserModule.bootstrap(dependencyRegistry);
     Core.EventEmitterModule.bootstrap(dependencyRegistry);
     Core.EventSubscriberModule.bootstrap(dependencyRegistry);


### PR DESCRIPTION
@ke1v I added here the basic structure for a `LinuxDesktopEnvironmentResolver`. What do you think about this? Here we have a small module that is responsible of resolving the current Linux desktop environment. This can be then used by other modules like the `LinuxAppIconExtractor` or the `LinuxApplicationRepository`. You can target your implementation against this branch.