### PR TITLE
fix: Use "utf8" encoding for Buffer on Base64 conversion

### DIFF
--- a/src/main/Extensions/Base64Conversion/Base64Converter.test.ts
+++ b/src/main/Extensions/Base64Conversion/Base64Converter.test.ts
@@ -6,11 +6,19 @@ describe(Base64Converter, () => {
         it("should return the correct base64 encoded value of a string", () => {
             expect(Base64Converter.encode("Test:1886")).toBe("VGVzdDoxODg2");
         });
+
+        it("should return the correct base64 encoded value of a string containing non-ASCII characters", () => {
+            expect(Base64Converter.encode("Zürich ist schön.")).toBe("WsO8cmljaCBpc3Qgc2Now7ZuLg==");
+        });
     });
 
     describe(Base64Converter.decode, () => {
         it("should return the correct decoded value of a base64 string", () => {
             expect(Base64Converter.decode("VGhpcyBpcyBhIHRlc3Qh")).toBe("This is a test!");
+        });
+
+        it("should return the correct decoded value of a base64 string containing non-ASCII characters", () => {
+            expect(Base64Converter.decode("4pyF8J+RjQ==")).toBe("✅👍");
         });
     });
 });

--- a/src/main/Extensions/Base64Conversion/Base64Converter.ts
+++ b/src/main/Extensions/Base64Conversion/Base64Converter.ts
@@ -2,10 +2,10 @@ import { Buffer } from "buffer";
 
 export class Base64Converter {
     public static encode(payload: string): string {
-        return Buffer.from(payload, "binary").toString("base64");
+        return Buffer.from(payload, "utf8").toString("base64");
     }
 
     public static decode(payload: string): string {
-        return Buffer.from(payload, "base64").toString("binary");
+        return Buffer.from(payload, "base64").toString("utf8");
     }
 }


### PR DESCRIPTION
Encoding specified for Buffer on Base64 Conversion should be “utf8”, not “binary”.
This causes that non-ASCII characters, Emoji, etc... are not encoded/decoded correctly.

For example: "thumbs-up"👍should be encoded as "8J+RjQ=="

```shell
# using coreutils on Linux shell
$ printf 👍 | base64
8J+RjQ==
```

but Base64 Conversion result:
![image](https://github.com/user-attachments/assets/5d4e8755-b0b6-4a8e-aa7b-e197a1b8201b)

This PR fix would make the following result:
![image](https://github.com/user-attachments/assets/002289e7-9932-4ed3-a05e-ee80a08fa05c)