### PR TITLE
Adjust how Jetbrains Toolbox extension loads projects

### DIFF
--- a/docs/Extensions/JetBrainsToolbox/README.md
+++ b/docs/Extensions/JetBrainsToolbox/README.md
@@ -13,6 +13,3 @@ Supported operating systems:
 -   Windows
 -   macOS
 -   Linux
-
-> [!IMPORTANT]
-> Requires "Generate shell scripts" to be enable in JetBrains Toolbox

--- a/src/main/Extensions/JetBrainsToolbox/JetBrainsToolboxModule.ts
+++ b/src/main/Extensions/JetBrainsToolbox/JetBrainsToolboxModule.ts
@@ -12,6 +12,7 @@ export class JetBrainsToolboxModule implements ExtensionModule {
                 dependencyRegistry.get("AssetPathResolver"),
                 dependencyRegistry.get("SettingsManager"),
                 dependencyRegistry.get("FileSystemUtility"),
+                dependencyRegistry.get("XmlParser"),
                 dependencyRegistry.get("Translator"),
             ),
         };


### PR DESCRIPTION
The current implementation does not show all projects. With these changes all recent project of all tools installed by the Toolbox will be shown with the icon of the tool (if no project icon is present).