### PR TITLE
:sparkles: Add option for setting a default target currency

### DIFF
--- a/src/main/Extensions/CurrencyConversion/CurrencyConversion.ts
+++ b/src/main/Extensions/CurrencyConversion/CurrencyConversion.ts
@@ -26,6 +26,7 @@ export class CurrencyConversion implements Extension {
 
     private readonly defaultSettings = {
         currencies: ["usd", "chf", "eur"],
+        defaultTargetCurrency: "eur",
     };
 
     private rates: Rates;
@@ -42,11 +43,17 @@ export class CurrencyConversion implements Extension {
         const parts = searchTerm.trim().split(" ");
 
         const validators = [
-            () => parts.length === 4,
+            () => parts.length === 2 || parts.length === 4,
             () => !isNaN(Number(parts[0])),
             () => Object.keys(this.rates).includes(parts[1].toLowerCase()),
-            () => ["in", "to"].includes(parts[2].toLowerCase()),
-            () => Object.keys(this.rates[parts[1].toLowerCase()]).includes(parts[3].toLowerCase()),
+            () => (parts.length === 4 ? ["in", "to"].includes(parts[2].toLowerCase()) : true),
+            () => {
+                const possibleTargetCurrencies = Object.keys(this.rates[parts[1].toLowerCase()]);
+                if (parts.length === 4) {
+                    return possibleTargetCurrencies.includes(parts[3].toLowerCase());
+                }
+                return possibleTargetCurrencies.includes(this.getDefaultTargetCurrency());
+            },
         ];
 
         for (const validator of validators) {
@@ -57,7 +64,7 @@ export class CurrencyConversion implements Extension {
 
         const value = Number(parts[0]);
         const base = parts[1];
-        const target = parts[3];
+        const target = parts.length === 4 ? parts[3].toLowerCase() : this.getDefaultTargetCurrency();
 
         const conversionResult = convert({ value, base, target, rates: this.rates });
 
@@ -78,7 +85,7 @@ export class CurrencyConversion implements Extension {
                 },
                 id: `currency-conversion:instant-result`,
                 image: this.getImage(),
-                name: `${conversionResult.result.toFixed(2)} ${parts[3].toUpperCase()}`,
+                name: `${conversionResult.result.toFixed(2)} ${target.toUpperCase()}`,
             },
         ];
     }
@@ -107,6 +114,7 @@ export class CurrencyConversion implements Extension {
             "en-US": {
                 extensionName: "Currency Conversion",
                 currencies: "Currencies",
+                defaultTargetCurrency: "Default Target Currency",
                 selectCurrencies: "Select currencies",
                 copyToClipboard: "Copy to clipboard",
                 currencyConversion: "Currency Conversion",
@@ -114,6 +122,7 @@ export class CurrencyConversion implements Extension {
             "de-CH": {
                 extensionName: "Währungsumrechnung",
                 currencies: "Währungen",
+                defaultTargetCurrency: "Standard-Zielwährung",
                 selectCurrencies: "Währungen wählen",
                 copyToClipboard: "In Zwischenablage kopieren",
                 currencyConversion: "Währungsumrechnung",
@@ -122,7 +131,10 @@ export class CurrencyConversion implements Extension {
     }
 
     public getSettingKeysTriggeringRescan(): string[] {
-        return [getExtensionSettingKey(this.id, "currencies")];
+        return [
+            getExtensionSettingKey(this.id, "currencies"),
+            getExtensionSettingKey(this.id, "defaultTargetCurrency"),
+        ];
     }
 
     private async setRates(): Promise<void> {
@@ -142,5 +154,12 @@ export class CurrencyConversion implements Extension {
         const responseJson = await response.json();
 
         this.rates[currency] = responseJson[currency];
+    }
+
+    private getDefaultTargetCurrency(): string {
+        return this.settingsManager.getValue<string>(
+            getExtensionSettingKey(this.id, "defaultTargetCurrency"),
+            this.getSettingDefaultValue<string>("defaultTargetCurrency"),
+        );
     }
 }

--- a/src/main/Extensions/CurrencyConversion/CurrencyConversion.ts
+++ b/src/main/Extensions/CurrencyConversion/CurrencyConversion.ts
@@ -46,14 +46,11 @@ export class CurrencyConversion implements Extension {
             () => parts.length === 2 || parts.length === 4,
             () => !isNaN(Number(parts[0])),
             () => Object.keys(this.rates).includes(parts[1].toLowerCase()),
-            () => (parts.length === 4 ? ["in", "to"].includes(parts[2].toLowerCase()) : true),
-            () => {
-                const possibleTargetCurrencies = Object.keys(this.rates[parts[1].toLowerCase()]);
-                if (parts.length === 4) {
-                    return possibleTargetCurrencies.includes(parts[3].toLowerCase());
-                }
-                return possibleTargetCurrencies.includes(this.getDefaultTargetCurrency());
-            },
+            () => parts.length === 2 || (parts.length === 4 && ["in", "to"].includes(parts[2].toLowerCase())),
+            () =>
+                Object.keys(this.rates[parts[1].toLowerCase()]).includes(
+                    parts.length === 4 ? parts[3].toLowerCase() : this.getDefaultTargetCurrency(),
+                ),
         ];
 
         for (const validator of validators) {

--- a/src/renderer/Extensions/CurrencyConversion/CurrencyConversionSettings.tsx
+++ b/src/renderer/Extensions/CurrencyConversion/CurrencyConversionSettings.tsx
@@ -14,6 +14,11 @@ export const CurrencyConversionSettings = () => {
         key: "currencies",
     });
 
+    const { value: defaultTargetCurrency, updateValue: setDefaultTargetCurrency } = useExtensionSetting<string>({
+        extensionId: "CurrencyConversion",
+        key: "defaultTargetCurrency",
+    });
+
     return (
         <SettingGroupList>
             <SettingGroup title={t("extensionName")}>
@@ -30,6 +35,25 @@ export const CurrencyConversionSettings = () => {
                             {Object.keys(availableCurrencies).map((availableCurrency) => (
                                 <Option key={availableCurrency} value={availableCurrency}>
                                     {`${availableCurrency.toUpperCase()} (${availableCurrencies[availableCurrency]})`}
+                                </Option>
+                            ))}
+                        </Dropdown>
+                    }
+                />
+                <Setting
+                    label={t("defaultTargetCurrency")}
+                    control={
+                        <Dropdown
+                            selectedOptions={[defaultTargetCurrency]}
+                            value={defaultTargetCurrency.toUpperCase()}
+                            placeholder={t("selectDefaultTargetCurrency")}
+                            onOptionSelect={(_, { optionValue }) =>
+                                optionValue && setDefaultTargetCurrency(optionValue)
+                            }
+                        >
+                            {currencies.map((currency) => (
+                                <Option key={currency} value={currency}>
+                                    {`${currency.toUpperCase()}`}
                                 </Option>
                             ))}
                         </Dropdown>


### PR DESCRIPTION
# Description

Hello (again)! I am back with the second round of default target currency! (I was the person who implemented this for the old version as well) 😅

Still love the app and still use it very frequently 🤘 So kudos! 🙏 

Fixes #1207 

## :sparkles: Default Target Currency
I added the option for setting a default target currency. This includes updating the settings panel and a bit of the code to handle the input in the case of just writing the shorthand version.

The settings part let's the user pick only from the already selected list of currencies.

> [!note]
> _Note that I tried adding the Swiss German translation for the setting, but since I do not actually speak this language very well a quick review from someone who does would be appreciated_ 🙏

## 📷  How It Looks
![image](https://github.com/user-attachments/assets/3b673ed5-d286-4a24-a15c-b3977b96f91b)


## 📝 Notes
Couple of things of note:
- The chosen currency list from the settings does not seem to be used in any way in the extension (or I am just too stupid to understand it)
- The validation of the input got slightly more messy. I think it is tolerable but feel free to add a comment 👍
- When setting a default and then removing that currency from the `Currencies` list, the default still stays. Due to some weird state management in React I was not able to get around this properly.
- No testing code has been written. If this is required/desired I would need a bit of time to familiarize myself with how to do this. Manual testing has been done and seems successful.