### PR TITLE
Add settings window resize

### DIFF
--- a/src/main/Core/BrowserWindow/BrowserWindowConstructorOptionsProvider/DefaultBrowserWindowConstructorOptionsProvider.test.ts
+++ b/src/main/Core/BrowserWindow/BrowserWindowConstructorOptionsProvider/DefaultBrowserWindowConstructorOptionsProvider.test.ts
@@ -4,7 +4,6 @@ import { join } from "path";
 import { describe, expect, it, vi } from "vitest";
 import type { AppIconFilePathResolver } from "../AppIconFilePathResolver";
 import { DefaultBrowserWindowConstructorOptionsProvider } from "./DefaultBrowserWindowConstructorOptionsProvider";
-import { defaultWindowSize } from "./defaultWindowSize";
 
 describe(DefaultBrowserWindowConstructorOptionsProvider, () => {
     describe(DefaultBrowserWindowConstructorOptionsProvider.prototype.get, () => {
@@ -18,8 +17,8 @@ describe(DefaultBrowserWindowConstructorOptionsProvider, () => {
             expect(
                 new DefaultBrowserWindowConstructorOptionsProvider(app, settingsManager, appIconFilePathResolver).get(),
             ).toEqual(<BrowserWindowConstructorOptions>{
-                width: defaultWindowSize.width,
-                height: defaultWindowSize.height,
+                width: undefined,
+                height: undefined,
                 alwaysOnTop: undefined,
                 show: undefined,
                 frame: false,
@@ -35,6 +34,7 @@ describe(DefaultBrowserWindowConstructorOptionsProvider, () => {
 
             expect(getValueMock).toHaveBeenCalledWith("window.showOnStartup", true);
             expect(getValueMock).toHaveBeenCalledWith("window.alwaysOnTop", false);
+            expect(getValueMock).toHaveBeenCalledWith("window.defaultWindowSize", { width: 600, height: 400 });
         });
 
         it("should allow insecure content and disable web security if app is not packaged", () => {

--- a/src/main/Core/BrowserWindow/BrowserWindowConstructorOptionsProvider/DefaultBrowserWindowConstructorOptionsProvider.ts
+++ b/src/main/Core/BrowserWindow/BrowserWindowConstructorOptionsProvider/DefaultBrowserWindowConstructorOptionsProvider.ts
@@ -3,7 +3,6 @@ import type { App } from "electron";
 import { join } from "path";
 import type { AppIconFilePathResolver } from "../AppIconFilePathResolver";
 import type { BrowserWindowConstructorOptionsProvider } from "./BrowserWindowConstructorOptionsProvider";
-import { defaultWindowSize } from "./defaultWindowSize";
 
 export class DefaultBrowserWindowConstructorOptionsProvider implements BrowserWindowConstructorOptionsProvider {
     public constructor(
@@ -13,6 +12,12 @@ export class DefaultBrowserWindowConstructorOptionsProvider implements BrowserWi
     ) {}
 
     public get(): Electron.BrowserWindowConstructorOptions {
+        const defaultWindowSize = this.settingsManager.getValue(
+            "window.defaultWindowSize",
+            { width: 600, height: 400 },
+            false,
+        );
+
         return {
             ...defaultWindowSize,
             frame: false,

--- a/src/main/Core/BrowserWindow/BrowserWindowConstructorOptionsProvider/defaultWindowSize.ts
+++ b/src/main/Core/BrowserWindow/BrowserWindowConstructorOptionsProvider/defaultWindowSize.ts
@@ -1,6 +1,0 @@
-import type { Size } from "electron";
-
-export const defaultWindowSize: Size = {
-    height: 400,
-    width: 600,
-};

--- a/src/main/Core/BrowserWindow/BrowserWindowConstructorOptionsProvider/index.ts
+++ b/src/main/Core/BrowserWindow/BrowserWindowConstructorOptionsProvider/index.ts
@@ -1,7 +1,6 @@
 export * from "./BackgroundMaterial";
 export * from "./BrowserWindowConstructorOptionsProvider";
 export * from "./DefaultBrowserWindowConstructorOptionsProvider";
-export * from "./defaultWindowSize";
 export * from "./LinuxBrowserWindowConstructorOptionsProvider";
 export * from "./MacOsBrowserWindowConstructorOptionsProvider";
 export * from "./Vibrancy";

--- a/src/main/Core/BrowserWindow/BrowserWindowModule.ts
+++ b/src/main/Core/BrowserWindow/BrowserWindowModule.ts
@@ -17,7 +17,6 @@ import {
     MacOsBrowserWindowConstructorOptionsProvider,
     VibrancyProvider,
     WindowsBrowserWindowConstructorOptionsProvider,
-    defaultWindowSize,
 } from "./BrowserWindowConstructorOptionsProvider";
 import { BrowserWindowCreator } from "./BrowserWindowCreator";
 import { BrowserWindowToggler } from "./BrowserWindowToggler";
@@ -66,6 +65,10 @@ export class BrowserWindowModule {
         ).create();
 
         browserWindow.setVisibleOnAllWorkspaces(settingsManager.getValue("window.visibleOnAllWorkspaces", false));
+        const defaultWindowSize = settingsManager.getValue("window.defaultWindowSize", {
+            width: 600,
+            height: 400,
+        });
 
         const browserWindowToggler = new BrowserWindowToggler(
             operatingSystem,
@@ -174,6 +177,13 @@ export class BrowserWindowModule {
         eventSubscriber.subscribe("navigateTo", ({ pathname }: { pathname: string }) => {
             browserWindowToggler.showAndFocus();
             sendToBrowserWindow(browserWindow, "navigateTo", { pathname });
+        });
+
+        ipcMain.on("resizeWindow", (e, data) => {
+            browserWindow.setSize(data.width, data.height);
+            if (data.center) {
+                browserWindow.center();
+            }
         });
 
         ipcMain.on("escapePressed", () => shouldHideWindowOnEscapePressed() && browserWindowToggler.hide());

--- a/src/renderer/Core/App.tsx
+++ b/src/renderer/Core/App.tsx
@@ -34,12 +34,24 @@ export const App = () => {
     useI18n({ contextBridge });
     useScrollBar({ document, theme });
 
+    const setThemeBackgroundColor = (theme: Theme) => {
+        const rootNode = document.querySelector("html");
+        if (rootNode) {
+            rootNode.style.backgroundColor = theme.colorNeutralBackground1;
+        }
+    };
+
     useEffect(() => {
-        const navigateToEventHandler = (_: IpcRendererEvent, { pathname }: { pathname: string }) =>
+        setThemeBackgroundColor(theme);
+        const navigateToEventHandler = (_: IpcRendererEvent, { pathname }: { pathname: string }) => {
+            console.log(pathname);
+
             navigate({ pathname });
+        };
 
         const nativeThemeChangedEventHandler = () => {
-            setTheme(getTheme(contextBridge));
+            const theme = getTheme(contextBridge);
+            setThemeBackgroundColor(theme);
             setShouldPreferDarkColors(window.matchMedia("(prefers-color-scheme: dark)").matches);
         };
 

--- a/src/renderer/Core/I18n/getCoreResources.ts
+++ b/src/renderer/Core/I18n/getCoreResources.ts
@@ -271,6 +271,8 @@ export const getCoreResources = (): { namespace: string; resources: Resources<Tr
                     "hideWindowOn.escapePressed": "Pressing escape key",
                     alwaysOnTop: "Always on top",
                     showOnStartup: "Show on startup",
+                    defaultWindowSize: "Default Window Size",
+                    defaultSettingsWindowSize: "Default Settings Window Size",
                     alwaysCenter: "Always center window",
                     scrollBehavior: "Scroll behavior",
                     "scrollBehavior.auto": "Auto",

--- a/src/renderer/Core/Settings/Pages/Window/Window.tsx
+++ b/src/renderer/Core/Settings/Pages/Window/Window.tsx
@@ -9,6 +9,7 @@ import { Opacity } from "./Opacity";
 import { ScrollBehavior } from "./ScrollBehavior";
 import { ShowOnStartup } from "./ShowOnStartup";
 import { Vibrancy } from "./Vibrancy";
+import { WindowSize } from "./WindowSize";
 import { WorkspaceVisibility } from "./WorkspaceVisibility";
 
 export const Window = () => {
@@ -33,6 +34,16 @@ export const Window = () => {
             </SettingGroup>
 
             <SettingGroup title="Appearance">
+                <WindowSize
+                    lable="defaultWindowSize"
+                    setting="window.defaultWindowSize"
+                    defaultValue={{ width: 600, height: 400 }}
+                />
+                <WindowSize
+                    lable="defaultSettingsWindowSize"
+                    setting="window.defaultSettingsWindowSize"
+                    defaultValue={{ width: 800, height: 600 }}
+                />
                 {operatingSystem === "Windows" && (
                     <BackgroundMaterial
                         backgroundMaterial={backgroundMaterial}

--- a/src/renderer/Core/Settings/Pages/Window/WindowSize.tsx
+++ b/src/renderer/Core/Settings/Pages/Window/WindowSize.tsx
@@ -1,0 +1,52 @@
+import { useSetting } from "@Core/Hooks";
+import { Setting } from "@Core/Settings/Setting";
+import { SpinButton } from "@fluentui/react-components";
+import type { Size } from "electron/main";
+import { useTranslation } from "react-i18next";
+
+export const WindowSize = ({
+    lable,
+    setting,
+    defaultValue,
+}: {
+    lable: string;
+    setting: string;
+    defaultValue: Size;
+}) => {
+    const { t } = useTranslation("settingsWindow");
+
+    const { value: windowSize, updateValue: setWindowSize } = useSetting<Size>({
+        key: setting,
+        defaultValue: defaultValue,
+    });
+
+    return (
+        <Setting
+            label={t(lable)}
+            control={
+                <span style={{ display: "flex", gap: 10 }}>
+                    <SpinButton
+                        min={300}
+                        value={windowSize.width}
+                        onChange={(_, { value, displayValue }) => {
+                            setWindowSize({
+                                width: Number(displayValue) || value || 0,
+                                height: windowSize.height,
+                            });
+                        }}
+                    />
+                    <SpinButton
+                        min={200}
+                        value={windowSize.height}
+                        onChange={(_, { value, displayValue }) => {
+                            setWindowSize({
+                                width: windowSize.width,
+                                height: Number(displayValue) || value || 0,
+                            });
+                        }}
+                    />
+                </span>
+            }
+        />
+    );
+};

--- a/src/renderer/Core/Settings/Settings.tsx
+++ b/src/renderer/Core/Settings/Settings.tsx
@@ -1,4 +1,5 @@
 import { useContextBridge } from "@Core/Hooks";
+import { useEffect } from "react";
 import { Route, Routes, useNavigate } from "react-router";
 import { ExtensionSettings } from "./ExtensionSettings";
 import { Navigation } from "./Navigation";
@@ -8,7 +9,26 @@ import { SettingsHeader } from "./SettingsHeader";
 export const Settings = () => {
     const { contextBridge } = useContextBridge();
     const navigate = useNavigate();
-    const closeSettings = () => navigate({ pathname: "/" });
+    const closeSettings = () => {
+        navigate({ pathname: "/" });
+        const size = contextBridge.getSettingValue("window.defaultWindowSize", { width: 600, height: 400 });
+
+        contextBridge.ipcRenderer.send("resizeWindow", {
+            center: true,
+            width: size.width,
+            height: size.height,
+        });
+    };
+
+    useEffect(() => {
+        const size = contextBridge.getSettingValue("window.defaultSettingsWindowSize", { width: 800, height: 600 });
+
+        contextBridge.ipcRenderer.send("resizeWindow", {
+            center: true,
+            width: size.width,
+            height: size.height,
+        });
+    }, []);
 
     return (
         <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>


### PR DESCRIPTION
Added support to have different sized windows when in the settings window vs normal also added a setting to configure the sizes of them by default.
Some css changes might be a good idea as rn there is a slight amount of lag to the ui changing as it resizes maybe just set the whole screen to the background color temporarly and hide all the ui or do some fading not to sure.

![image](https://github.com/user-attachments/assets/905003c5-72fa-4c0b-b126-49126719d47a)

![image](https://github.com/user-attachments/assets/7c2c72d6-2118-4f0b-b114-743214ea146f)

This helps fix alot of the settings UI bugs where buttons and dropdowns are squashed or overflowing kinda of a patch to that bug but I plan on fixing that properly soon but this was a small addition that I extracted while messing around with that idea.
