### PR TITLE
feat(tsconfig): add "noUnusedLocals" rule to prevent unused class properties

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,15 +1,16 @@
 {
     "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
         "composite": true,
         "module": "ESNext",
         "moduleResolution": "Node",
-        "resolveJsonModule": true,
-        "allowSyntheticDefaultImports": true,
-        "rootDir": "./src",
-        "skipLibCheck": true,
+        "noUnusedLocals": true,
         "paths": {
             "@common/*": ["./src/common/*"],
             "@Core/*": ["./src/main/Core/*"]
-        }
+        },
+        "resolveJsonModule": true,
+        "rootDir": "./src",
+        "skipLibCheck": true
     }
 }

--- a/tsconfig.renderer.json
+++ b/tsconfig.renderer.json
@@ -1,24 +1,25 @@
 {
     "compilerOptions": {
-        "target": "ESNext",
-        "useDefineForClassFields": true,
-        "lib": ["DOM", "DOM.Iterable", "ESNext"],
         "allowJs": false,
-        "skipLibCheck": true,
-        "esModuleInterop": false,
         "allowSyntheticDefaultImports": true,
-        "strict": true,
+        "esModuleInterop": false,
         "forceConsistentCasingInFileNames": true,
+        "isolatedModules": true,
+        "jsx": "react-jsx",
+        "lib": ["DOM", "DOM.Iterable", "ESNext"],
         "module": "ESNext",
         "moduleResolution": "Node",
-        "resolveJsonModule": true,
-        "isolatedModules": true,
         "noEmit": true,
-        "jsx": "react-jsx",
-        "rootDir": "./src",
+        "noUnusedLocals": true,
         "paths": {
             "@common/*": ["./src/common/*"],
             "@Core/*": ["./src/renderer/Core/*"]
-        }
+        },
+        "resolveJsonModule": true,
+        "rootDir": "./src",
+        "skipLibCheck": true,
+        "strict": true,
+        "target": "ESNext",
+        "useDefineForClassFields": true
     }
 }


### PR DESCRIPTION
As eslint does not catch unused class properties we add the rule for the typescript compiler.