### PR TITLE
fix(WindowsApplicationIconExtractor): ignore case of file extension

### DIFF
--- a/src/main/Core/ImageGenerator/Windows/WindowsApplicationIconExtractor.test.ts
+++ b/src/main/Core/ImageGenerator/Windows/WindowsApplicationIconExtractor.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { WindowsApplicationIconExtractor } from "./WindowsApplicationIconExtractor";
+
+describe(WindowsApplicationIconExtractor, () => {
+    describe(WindowsApplicationIconExtractor.prototype.matchesFilePath, () => {
+        const testMatchesFilePath = ({ filePath, expected }: { filePath: string; expected: boolean }) =>
+            expect(new WindowsApplicationIconExtractor(null, null, null, "").matchesFilePath(filePath)).toBe(expected);
+
+        it("should return true when file path ends with .lnk, .url, .appref-ms, .exe", () => {
+            const filePaths = [
+                "file.lnk",
+                "file.url",
+                "file.appref-ms",
+                "file.exe",
+                "file.LNK",
+                "file.URL",
+                "file.APPREF-MS",
+                "file.EXE",
+            ];
+
+            for (const filePath of filePaths) {
+                testMatchesFilePath({ filePath, expected: true });
+            }
+        });
+
+        it("should return false when file path ends with other file extensions", () => {
+            const filePaths = [
+                "",
+                " ",
+                "file",
+                "file.ln",
+                "file.ex",
+                "lnk",
+                "exe",
+                "file.txt",
+                "file.doc",
+                "file.docx",
+                "file.pdf",
+                "file.jpg",
+                "file.png",
+            ];
+
+            for (const filePath of filePaths) {
+                testMatchesFilePath({ filePath, expected: false });
+            }
+        });
+    });
+});

--- a/src/main/Core/ImageGenerator/Windows/WindowsApplicationIconExtractor.ts
+++ b/src/main/Core/ImageGenerator/Windows/WindowsApplicationIconExtractor.ts
@@ -15,11 +15,8 @@ export class WindowsApplicationIconExtractor implements FileIconExtractor {
     ) {}
 
     public matchesFilePath(filePath: string) {
-        return (
-            filePath.endsWith(".lnk") ||
-            filePath.endsWith(".url") ||
-            filePath.endsWith(".appref-ms") ||
-            filePath.endsWith(".exe")
+        return [".lnk", ".url", ".appref-ms", ".exe"].some((fileExtension) =>
+            filePath.toLowerCase().endsWith(fileExtension),
         );
     }
 


### PR DESCRIPTION
Title says it all.

Fixes potentially #1133