### PR TITLE
feat: make fuzzysort new default search engine

### DIFF
--- a/src/main/Extensions/JetBrainsToolbox/JetBrainsToolboxExtension.ts
+++ b/src/main/Extensions/JetBrainsToolbox/JetBrainsToolboxExtension.ts
@@ -253,7 +253,7 @@ export class JetBrainsToolboxExtension implements Extension {
 
         const fuzziness = this.settingsManager.getValue<number>("searchEngine.fuzziness", 0.5);
         const maxSearchResultItems = this.settingsManager.getValue<number>("searchEngine.maxResultLength", 50);
-        const searchEngineId = this.settingsManager.getValue<SearchEngineId>("searchEngine.id", "Fuse.js");
+        const searchEngineId = this.settingsManager.getValue<SearchEngineId>("searchEngine.id", "fuzzysort");
 
         return searchFilter(
             {

--- a/src/main/Extensions/VSCode/VSCodeExtension.ts
+++ b/src/main/Extensions/VSCode/VSCodeExtension.ts
@@ -226,7 +226,7 @@ export class VSCodeExtension implements Extension {
 
         const fuzziness = this.settingsManager.getValue<number>("searchEngine.fuzziness", 0.5);
         const maxSearchResultItems = this.settingsManager.getValue<number>("searchEngine.maxResultLength", 50);
-        const searchEngineId = this.settingsManager.getValue<SearchEngineId>("searchEngine.id", "Fuse.js");
+        const searchEngineId = this.settingsManager.getValue<SearchEngineId>("searchEngine.id", "fuzzysort");
 
         return searchFilter(
             {

--- a/src/renderer/Core/Search/SearchViewController.ts
+++ b/src/renderer/Core/Search/SearchViewController.ts
@@ -65,7 +65,7 @@ export const useSearchViewController = ({
 
     const { value: fuzziness } = useSetting({ key: "searchEngine.fuzziness", defaultValue: 0.5 });
     const { value: maxSearchResultItems } = useSetting({ key: "searchEngine.maxResultLength", defaultValue: 50 });
-    const { value: searchEngineId } = useSetting<SearchEngineId>({ key: "searchEngine.id", defaultValue: "Fuse.js" });
+    const { value: searchEngineId } = useSetting<SearchEngineId>({ key: "searchEngine.id", defaultValue: "fuzzysort" });
 
     const search = (searchTerm: string, selectedItemId?: string) => {
         const searchResult = getSearchResult({

--- a/src/renderer/Core/Settings/Pages/SearchEngine/SearchEngineId.tsx
+++ b/src/renderer/Core/Settings/Pages/SearchEngine/SearchEngineId.tsx
@@ -9,7 +9,7 @@ export const SearchEngineId = () => {
 
     const { value: searchEngineId, updateValue: setSearchEngineId } = useSetting({
         key: "searchEngine.id",
-        defaultValue: "Fuse.js",
+        defaultValue: "fuzzysort",
     });
 
     return (


### PR DESCRIPTION
This PR makes "fuzzysort" the new default search engine as (in my opinion) it leads to better search results.