### PR TITLE
refactor(JetBrainsToolboxExtension): move resolving of search result items to `getSearchResultItems`

### DIFF
--- a/src/main/Extensions/JetBrainsToolbox/JetBrainsToolboxModule.ts
+++ b/src/main/Extensions/JetBrainsToolbox/JetBrainsToolboxModule.ts
@@ -10,7 +10,6 @@ export class JetBrainsToolboxModule implements ExtensionModule {
             extension: new JetBrainsToolboxExtension(
                 dependencyRegistry.get("OperatingSystem"),
                 dependencyRegistry.get("AssetPathResolver"),
-                dependencyRegistry.get("SettingsManager"),
                 dependencyRegistry.get("FileSystemUtility"),
                 dependencyRegistry.get("XmlParser"),
                 dependencyRegistry.get("Translator"),


### PR DESCRIPTION
As the method `getInstantSearchResults` will be invoked on every keystroke we should keep it as lightweight as possible. This PR moves all functionality from `getInstantSearchResultItems` to `getSearchResultItems` which will be executed periodically and asynchronously, not blocking the user input field.

The behavior of the extension is unchanged (I think). @scomans Please confirm.