### PR TITLE
[VSCode ext] Fix bug when filename and folder are the same

### DIFF
--- a/src/main/Extensions/VSCode/VSCodeExtension.ts
+++ b/src/main/Extensions/VSCode/VSCodeExtension.ts
@@ -160,7 +160,7 @@ export class VSCodeExtension implements Extension {
         );
 
         return {
-            id: "vscode-" + uri,
+            id: `vscode-${fileType}-${uri}`,
             name: recent.label ?? Path.basename(path),
             description: fileType,
             image: img,


### PR DESCRIPTION
Fix bug when 2 entries where filename and folder are the same it will just open whatever the path actually is regardless of which one you press