### PR TITLE
refactor: remove `useContextBridge` hook

### DIFF
--- a/src/renderer/Core/App.tsx
+++ b/src/renderer/Core/App.tsx
@@ -4,13 +4,7 @@ import type { IpcRendererEvent } from "electron";
 import { useEffect, useState } from "react";
 import { Route, Routes, useNavigate } from "react-router";
 import { Extension } from "./Extension";
-import {
-    useContextBridge,
-    useExcludedSearchResultItems,
-    useFavorites,
-    useScrollBar,
-    useSearchResultItems,
-} from "./Hooks";
+import { useExcludedSearchResultItems, useFavorites, useScrollBar, useSearchResultItems } from "./Hooks";
 import { useI18n } from "./I18n";
 import { Search } from "./Search";
 import { Settings } from "./Settings";
@@ -19,8 +13,7 @@ import { ThemeContext } from "./ThemeContext";
 import { useAppCssProperties } from "./useAppCssProperties";
 
 export const App = () => {
-    const { contextBridge } = useContextBridge();
-    const [theme, setTheme] = useState<Theme>(getTheme(contextBridge));
+    const [theme, setTheme] = useState<Theme>(getTheme(window.ContextBridge));
     const [shouldPreferDarkColors, setShouldPreferDarkColors] = useState<boolean>(
         window.matchMedia("(prefers-color-scheme: dark)").matches,
     );
@@ -31,7 +24,7 @@ export const App = () => {
     const navigate = useNavigate();
     const { appCssProperties } = useAppCssProperties();
 
-    useI18n({ contextBridge });
+    useI18n();
     useScrollBar({ document, theme });
 
     useEffect(() => {
@@ -39,16 +32,16 @@ export const App = () => {
             navigate({ pathname });
 
         const nativeThemeChangedEventHandler = () => {
-            setTheme(getTheme(contextBridge));
+            setTheme(getTheme(window.ContextBridge));
             setShouldPreferDarkColors(window.matchMedia("(prefers-color-scheme: dark)").matches);
         };
 
-        contextBridge.ipcRenderer.on("navigateTo", navigateToEventHandler);
-        contextBridge.ipcRenderer.on("nativeThemeChanged", nativeThemeChangedEventHandler);
+        window.ContextBridge.ipcRenderer.on("navigateTo", navigateToEventHandler);
+        window.ContextBridge.ipcRenderer.on("nativeThemeChanged", nativeThemeChangedEventHandler);
 
         return () => {
-            contextBridge.ipcRenderer.off("navigateTo", navigateToEventHandler);
-            contextBridge.ipcRenderer.off("nativeThemeChanged", nativeThemeChangedEventHandler);
+            window.ContextBridge.ipcRenderer.off("navigateTo", navigateToEventHandler);
+            window.ContextBridge.ipcRenderer.off("nativeThemeChanged", nativeThemeChangedEventHandler);
         };
     }, []);
 

--- a/src/renderer/Core/Components/BasicSearch.tsx
+++ b/src/renderer/Core/Components/BasicSearch.tsx
@@ -1,6 +1,5 @@
 import { BaseLayout } from "@Core/BaseLayout";
 import { Header } from "@Core/Header";
-import { useContextBridge } from "@Core/Hooks";
 import { getNextSearchResultItemId } from "@Core/Search/Helpers/getNextSearchResultItemId";
 import { getPreviousSearchResultItemId } from "@Core/Search/Helpers/getPreviousSearchResultItemId";
 import { SearchResultList } from "@Core/Search/SearchResultList";
@@ -24,7 +23,6 @@ export const BasicSearch = ({
     debounceDurationInMs,
     showGoBackButton,
 }: BasicSearchProps) => {
-    const { contextBridge } = useContextBridge();
     const navigate = useNavigate();
     const [searchTerm, setSearchTerm] = useState<string>("");
     const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -64,17 +62,17 @@ export const BasicSearch = ({
         const selectedSearchResultItem = getSelectedSearchResultItem();
 
         if (selectedSearchResultItem) {
-            await contextBridge.invokeAction(selectedSearchResultItem.defaultAction);
+            await window.ContextBridge.invokeAction(selectedSearchResultItem.defaultAction);
         }
     };
 
     const clickHandlers: Record<string, (s: SearchResultItem) => void> = {
         selectSearchResultItem: (s) => setSelectedItemId(s.id),
-        invokeSearchResultItem: (s) => contextBridge.invokeAction(s.defaultAction),
+        invokeSearchResultItem: (s) => window.ContextBridge.invokeAction(s.defaultAction),
     };
 
     const handleSearchResultItemClickEvent = (searchResultItem: SearchResultItem) => {
-        const singleClickBehavior = contextBridge.getSettingValue(
+        const singleClickBehavior = window.ContextBridge.getSettingValue(
             "keyboardAndMouse.singleClickBehavior",
             "selectSearchResultItem",
         );
@@ -83,7 +81,7 @@ export const BasicSearch = ({
     };
 
     const handleSearchResultItemDoubleClickEvent = (searchResultItem: SearchResultItem) => {
-        const doubleClickBehavior = contextBridge.getSettingValue(
+        const doubleClickBehavior = window.ContextBridge.getSettingValue(
             "keyboardAndMouse.doubleClickBehavior",
             "invokeSearchResultItem",
         );

--- a/src/renderer/Core/Hooks/index.ts
+++ b/src/renderer/Core/Hooks/index.ts
@@ -1,4 +1,3 @@
-export * from "./useContextBridge";
 export * from "./useExcludedSearchResultItems";
 export * from "./useExtensionProps";
 export * from "./useExtensionSetting";

--- a/src/renderer/Core/Hooks/useContextBridge.ts
+++ b/src/renderer/Core/Hooks/useContextBridge.ts
@@ -1,3 +1,0 @@
-import type { ContextBridge } from "@common/Core";
-
-export const useContextBridge = (): { contextBridge: ContextBridge } => ({ contextBridge: window.ContextBridge });

--- a/src/renderer/Core/Hooks/useExcludedSearchResultItems.ts
+++ b/src/renderer/Core/Hooks/useExcludedSearchResultItems.ts
@@ -1,21 +1,21 @@
 import { useEffect, useState } from "react";
-import { useContextBridge } from "./useContextBridge";
 
 export const useExcludedSearchResultItems = () => {
-    const { contextBridge } = useContextBridge();
-
     const [excludedSearchResultItemIds, setExcludedSearchResultItemIds] = useState<string[]>(
-        contextBridge.getExcludedSearchResultItemIds(),
+        window.ContextBridge.getExcludedSearchResultItemIds(),
     );
 
     useEffect(() => {
         const excludedSearchResultItemsUpdatedEventHandler = () =>
-            setExcludedSearchResultItemIds(contextBridge.getExcludedSearchResultItemIds());
+            setExcludedSearchResultItemIds(window.ContextBridge.getExcludedSearchResultItemIds());
 
-        contextBridge.ipcRenderer.on("excludedSearchResultItemsUpdated", excludedSearchResultItemsUpdatedEventHandler);
+        window.ContextBridge.ipcRenderer.on(
+            "excludedSearchResultItemsUpdated",
+            excludedSearchResultItemsUpdatedEventHandler,
+        );
 
         return () => {
-            contextBridge.ipcRenderer.off(
+            window.ContextBridge.ipcRenderer.off(
                 "excludedSearchResultItemsUpdated",
                 excludedSearchResultItemsUpdatedEventHandler,
             );

--- a/src/renderer/Core/Hooks/useExtensionProps.ts
+++ b/src/renderer/Core/Hooks/useExtensionProps.ts
@@ -1,13 +1,11 @@
 import type { ExtensionProps } from "@Core/ExtensionProps";
 import { useNavigate } from "react-router";
-import { useContextBridge } from "./useContextBridge";
 
 export const useExtensionProps = (): ExtensionProps => {
     const navigate = useNavigate();
-    const { contextBridge } = useContextBridge();
 
     return {
-        contextBridge,
+        contextBridge: window.ContextBridge,
         goBack: () => navigate({ pathname: "/" }),
     };
 };

--- a/src/renderer/Core/Hooks/useExtensionSetting.ts
+++ b/src/renderer/Core/Hooks/useExtensionSetting.ts
@@ -1,6 +1,5 @@
 import { getExtensionSettingKey } from "@common/Core/Extension";
 import { useState } from "react";
-import { useContextBridge } from "./useContextBridge";
 
 export const useExtensionSetting = <Value>({
     extensionId,
@@ -11,14 +10,12 @@ export const useExtensionSetting = <Value>({
     key: string;
     isSensitive?: boolean;
 }) => {
-    const { contextBridge } = useContextBridge();
-
     const settingKey = getExtensionSettingKey(extensionId, key);
 
     const [value, setValue] = useState<Value>(
-        contextBridge.getSettingValue(
+        window.ContextBridge.getSettingValue(
             settingKey,
-            contextBridge.getExtensionSettingDefaultValue(extensionId, key),
+            window.ContextBridge.getExtensionSettingDefaultValue(extensionId, key),
             isSensitive,
         ),
     );
@@ -26,7 +23,7 @@ export const useExtensionSetting = <Value>({
     const updateValue = async (updatedValue: Value) => {
         setValue(updatedValue);
 
-        await contextBridge.updateSettingValue(settingKey, updatedValue, isSensitive);
+        await window.ContextBridge.updateSettingValue(settingKey, updatedValue, isSensitive);
     };
 
     return { value, updateValue };

--- a/src/renderer/Core/Hooks/useFavorites.ts
+++ b/src/renderer/Core/Hooks/useFavorites.ts
@@ -1,18 +1,15 @@
 import { useEffect, useState } from "react";
-import { useContextBridge } from "./useContextBridge";
 
 export const useFavorites = () => {
-    const { contextBridge } = useContextBridge();
-
-    const [favorites, setFavorites] = useState<string[]>(contextBridge.getFavorites());
+    const [favorites, setFavorites] = useState<string[]>(window.ContextBridge.getFavorites());
 
     useEffect(() => {
-        const favoritesUpdatedEventHandler = () => setFavorites(contextBridge.getFavorites());
+        const favoritesUpdatedEventHandler = () => setFavorites(window.ContextBridge.getFavorites());
 
-        contextBridge.ipcRenderer.on("favoritesUpdated", favoritesUpdatedEventHandler);
+        window.ContextBridge.ipcRenderer.on("favoritesUpdated", favoritesUpdatedEventHandler);
 
         return () => {
-            contextBridge.ipcRenderer.off("favoritesUpdated", favoritesUpdatedEventHandler);
+            window.ContextBridge.ipcRenderer.off("favoritesUpdated", favoritesUpdatedEventHandler);
         };
     }, []);
 

--- a/src/renderer/Core/Hooks/useSearchResultItems.ts
+++ b/src/renderer/Core/Hooks/useSearchResultItems.ts
@@ -1,21 +1,18 @@
 import type { SearchResultItem } from "@common/Core";
 import { useEffect, useState } from "react";
-import { useContextBridge } from "./useContextBridge";
 
 export const useSearchResultItems = () => {
-    const { contextBridge } = useContextBridge();
-
     const [searchResultItems, setSearchResultItems] = useState<SearchResultItem[]>(
-        contextBridge.getSearchResultItems(),
+        window.ContextBridge.getSearchResultItems(),
     );
 
     useEffect(() => {
-        const searchIndexUpdatedEventHandler = () => setSearchResultItems(contextBridge.getSearchResultItems());
+        const searchIndexUpdatedEventHandler = () => setSearchResultItems(window.ContextBridge.getSearchResultItems());
 
-        contextBridge.ipcRenderer.on("searchIndexUpdated", searchIndexUpdatedEventHandler);
+        window.ContextBridge.ipcRenderer.on("searchIndexUpdated", searchIndexUpdatedEventHandler);
 
         return () => {
-            contextBridge.ipcRenderer.off("searchIndexUpdated", searchIndexUpdatedEventHandler);
+            window.ContextBridge.ipcRenderer.off("searchIndexUpdated", searchIndexUpdatedEventHandler);
         };
     }, []);
 

--- a/src/renderer/Core/Hooks/useSetting.ts
+++ b/src/renderer/Core/Hooks/useSetting.ts
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useContextBridge } from "./useContextBridge";
 
 export const useSetting = <Value>({
     key,
@@ -10,13 +9,11 @@ export const useSetting = <Value>({
     defaultValue: Value;
     isSensitive?: boolean;
 }) => {
-    const { contextBridge } = useContextBridge();
-
-    const [value, setValue] = useState<Value>(contextBridge.getSettingValue(key, defaultValue, isSensitive));
+    const [value, setValue] = useState<Value>(window.ContextBridge.getSettingValue(key, defaultValue, isSensitive));
 
     const updateValue = async (updatedValue: Value) => {
         setValue(updatedValue);
-        await contextBridge.updateSettingValue(key, updatedValue, isSensitive);
+        await window.ContextBridge.updateSettingValue(key, updatedValue, isSensitive);
     };
 
     return { value, updateValue };

--- a/src/renderer/Core/I18n/useI18n.ts
+++ b/src/renderer/Core/I18n/useI18n.ts
@@ -1,17 +1,16 @@
-import type { ContextBridge } from "@common/Core";
 import { use } from "i18next";
 import { initReactI18next } from "react-i18next";
 import { createResources } from "./createResources";
 import { getCoreResources } from "./getCoreResources";
 import { getExtensionResources } from "./getExtensionResources";
 
-export const useI18n = ({ contextBridge }: { contextBridge: ContextBridge }) => {
+export const useI18n = () => {
     return use(initReactI18next).init({
         resources: createResources([
             ...getCoreResources(),
-            ...getExtensionResources(contextBridge.getExtensionResources()),
+            ...getExtensionResources(window.ContextBridge.getExtensionResources()),
         ]),
-        lng: contextBridge.getSettingValue("general.language", "en-US"),
+        lng: window.ContextBridge.getSettingValue("general.language", "en-US"),
         fallbackLng: "en-US",
     });
 };

--- a/src/renderer/Core/Search/ActionsMenu/ActionsMenu.tsx
+++ b/src/renderer/Core/Search/ActionsMenu/ActionsMenu.tsx
@@ -1,5 +1,4 @@
 import { KeyboardShortcut } from "@Core/Components";
-import { useContextBridge } from "@Core/Hooks";
 import { type SearchResultItem, type SearchResultItemAction } from "@common/Core";
 import {
     Button,
@@ -38,7 +37,6 @@ export const ActionsMenu = ({
     onOpenChange,
     keyboardShortcut,
 }: AdditionalActionsProps) => {
-    const { contextBridge } = useContextBridge();
     const { t } = useTranslation();
 
     const toasterId = useId("copiedToClipboardToasterId");
@@ -46,7 +44,10 @@ export const ActionsMenu = ({
 
     const actions = searchResultItem ? getActions(searchResultItem, favorites) : [];
 
-    const showKeyboardShortcuts = contextBridge.getSettingValue<boolean>("appearance.showKeyboardShortcuts", true);
+    const showKeyboardShortcuts = window.ContextBridge.getSettingValue<boolean>(
+        "appearance.showKeyboardShortcuts",
+        true,
+    );
 
     useEffect(() => {
         const copiedToClipboardHandler = () =>
@@ -57,10 +58,10 @@ export const ActionsMenu = ({
                 { intent: "success", position: "bottom" },
             );
 
-        contextBridge.ipcRenderer.on("copiedToClipboard", copiedToClipboardHandler);
+        window.ContextBridge.ipcRenderer.on("copiedToClipboard", copiedToClipboardHandler);
 
         return () => {
-            contextBridge.ipcRenderer.off("copiedToClipboard", copiedToClipboardHandler);
+            window.ContextBridge.ipcRenderer.off("copiedToClipboard", copiedToClipboardHandler);
         };
     }, []);
 

--- a/src/renderer/Core/Search/ConfirmationDialog.tsx
+++ b/src/renderer/Core/Search/ConfirmationDialog.tsx
@@ -9,7 +9,6 @@ import {
     DialogTitle,
 } from "@fluentui/react-components";
 import { t } from "i18next";
-import { useContextBridge } from "../Hooks";
 
 type ConfirmationDialogProps = {
     action?: SearchResultItemAction;
@@ -17,12 +16,10 @@ type ConfirmationDialogProps = {
 };
 
 export const ConfirmationDialog = ({ action, closeDialog }: ConfirmationDialogProps) => {
-    const { contextBridge } = useContextBridge();
-
     const invokeAction = async () => {
         if (action) {
             closeDialog();
-            await contextBridge.invokeAction(action);
+            await window.ContextBridge.invokeAction(action);
         }
     };
 

--- a/src/renderer/Core/Search/Search.tsx
+++ b/src/renderer/Core/Search/Search.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { BaseLayout } from "../BaseLayout";
 import { Footer } from "../Footer";
-import { useContextBridge } from "../Hooks";
 import { ActionsMenu } from "./ActionsMenu";
 import { ConfirmationDialog } from "./ConfirmationDialog";
 import type { KeyboardEventHandler } from "./KeyboardEventHandler";
@@ -33,7 +32,6 @@ export const Search = ({
     favoriteSearchResultItemIds,
 }: SearchProps) => {
     const { t } = useTranslation("search");
-    const { contextBridge } = useContextBridge();
     const { theme } = useContext(ThemeContext);
 
     const [additionalActionsMenuIsOpen, setAdditionalActionsMenuIsOpen] = useState(false);
@@ -48,25 +46,24 @@ export const Search = ({
         invokeAction,
         invokeSelectedSearchResultItem,
     } = useSearchViewController({
-        contextBridge,
         searchResultItems,
         excludedSearchResultItemIds,
         favoriteSearchResultItemIds,
     });
 
-    const searchHistory = useSearchHistoryController({ contextBridge });
+    const searchHistory = useSearchHistoryController();
     const containerRef = useRef<HTMLDivElement>(null);
     const additionalActionsButtonRef = useRef<HTMLButtonElement>(null);
 
     const navigate = useNavigate();
     const openSettings = () => navigate({ pathname: "/settings/general" });
 
-    const singleClickBehavior = contextBridge.getSettingValue(
+    const singleClickBehavior = window.ContextBridge.getSettingValue(
         "keyboardAndMouse.singleClickBehavior",
         "selectSearchResultItem",
     );
 
-    const doubleClickBehavior = contextBridge.getSettingValue(
+    const doubleClickBehavior = window.ContextBridge.getSettingValue(
         "keyboardAndMouse.doubleClickBehavior",
         "invokeSearchResultItem",
     );
@@ -74,7 +71,7 @@ export const Search = ({
     const handleUserInputKeyDownEvent = (keyboardEvent: ReactKeyboardEvent<HTMLElement>) => {
         const eventHandlers: KeyboardEventHandler[] = [
             {
-                listener: () => contextBridge.ipcRenderer.send("escapePressed"),
+                listener: () => window.ContextBridge.ipcRenderer.send("escapePressed"),
                 needsToInvokeListener: (keyboardEvent) => keyboardEvent.key === "Escape",
             },
             {
@@ -131,7 +128,10 @@ export const Search = ({
         userInput.focus();
     };
 
-    const showKeyboardShortcuts = contextBridge.getSettingValue<boolean>("appearance.showKeyboardShortcuts", true);
+    const showKeyboardShortcuts = window.ContextBridge.getSettingValue<boolean>(
+        "appearance.showKeyboardShortcuts",
+        true,
+    );
 
     const toggleAdditionalActionsMenu = (open: boolean) => {
         setAdditionalActionsMenuIsOpen(open);
@@ -148,7 +148,7 @@ export const Search = ({
     }[] = [
         {
             validate: (event) =>
-                contextBridge.getOperatingSystem() === "macOS"
+                window.ContextBridge.getOperatingSystem() === "macOS"
                     ? event.key === "," && event.metaKey
                     : event.key === "," && event.ctrlKey,
             action: (event) => {
@@ -158,7 +158,7 @@ export const Search = ({
         },
         {
             validate: (event) =>
-                contextBridge.getOperatingSystem() === "macOS"
+                window.ContextBridge.getOperatingSystem() === "macOS"
                     ? event.key === "k" && event.metaKey
                     : event.key === "k" && event.ctrlKey,
             action: (event) => {
@@ -192,11 +192,11 @@ export const Search = ({
             }
         };
 
-        contextBridge.ipcRenderer.on("windowFocused", windowFocusedEventHandler);
+        window.ContextBridge.ipcRenderer.on("windowFocused", windowFocusedEventHandler);
         window.addEventListener("keydown", keyDownEventHandler);
 
         return () => {
-            contextBridge.ipcRenderer.off("windowFocused", windowFocusedEventHandler);
+            window.ContextBridge.ipcRenderer.off("windowFocused", windowFocusedEventHandler);
             window.removeEventListener("keydown", keyDownEventHandler);
         };
     }, []);
@@ -229,19 +229,19 @@ export const Search = ({
                         onKeyDown={handleUserInputKeyDownEvent}
                         onSearchTermUpdated={search}
                         searchTerm={searchTerm.value}
-                        searchBarSize={contextBridge.getSettingValue<SearchBarSize>(
+                        searchBarSize={window.ContextBridge.getSettingValue<SearchBarSize>(
                             "appearance.searchBarSize",
                             "large",
                         )}
-                        searchBarAppearance={contextBridge.getSettingValue<SearchBarAppearance>(
+                        searchBarAppearance={window.ContextBridge.getSettingValue<SearchBarAppearance>(
                             "appearance.searchBarAppearance",
                             "auto",
                         )}
-                        searchBarPlaceholderText={contextBridge.getSettingValue(
+                        searchBarPlaceholderText={window.ContextBridge.getSettingValue(
                             "appearance.searchBarPlaceholderText",
                             t("searchBarPlaceholderText"),
                         )}
-                        showIcon={contextBridge.getSettingValue("appearance.showSearchIcon", true)}
+                        showIcon={window.ContextBridge.getSettingValue("appearance.showSearchIcon", true)}
                         contentAfter={
                             searchHistory.isEnabled() ? (
                                 <SearchHistory
@@ -259,7 +259,7 @@ export const Search = ({
             }
             contentRef={containerRef}
             content={
-                contextBridge.getScanCount() === 0 ? (
+                window.ContextBridge.getScanCount() === 0 ? (
                     <ScanIndicator />
                 ) : (
                     <>
@@ -316,7 +316,7 @@ export const Search = ({
                         {showKeyboardShortcuts && (
                             <div style={{ paddingLeft: 5 }}>
                                 <KeyboardShortcut
-                                    shortcut={contextBridge.getOperatingSystem() === "macOS" ? "⌘+," : "^+,"}
+                                    shortcut={window.ContextBridge.getOperatingSystem() === "macOS" ? "⌘+," : "^+,"}
                                 />
                             </div>
                         )}
@@ -344,7 +344,7 @@ export const Search = ({
                             additionalActionsButtonRef={additionalActionsButtonRef}
                             open={additionalActionsMenuIsOpen}
                             onOpenChange={toggleAdditionalActionsMenu}
-                            keyboardShortcut={contextBridge.getOperatingSystem() === "macOS" ? "⌘+K" : "^+K"}
+                            keyboardShortcut={window.ContextBridge.getOperatingSystem() === "macOS" ? "⌘+K" : "^+K"}
                         />
                     </div>
                 </Footer>

--- a/src/renderer/Core/Search/SearchBar.tsx
+++ b/src/renderer/Core/Search/SearchBar.tsx
@@ -1,4 +1,3 @@
-import { useContextBridge } from "@Core/Hooks";
 import { Input } from "@fluentui/react-components";
 import { SearchRegular } from "@fluentui/react-icons";
 import type { ChangeEvent, KeyboardEvent, ReactElement, RefObject } from "react";
@@ -28,8 +27,6 @@ export const SearchBar = ({
     searchBarSize,
     showIcon,
 }: SearchBarProps) => {
-    const { contextBridge } = useContextBridge();
-
     const onChange = onSearchTermUpdated
         ? (_: ChangeEvent<HTMLInputElement>, { value }: { value: string }) => onSearchTermUpdated(value)
         : undefined;
@@ -40,7 +37,7 @@ export const SearchBar = ({
             ref={refObject}
             appearance={
                 searchBarAppearance === "auto"
-                    ? contextBridge.themeShouldUseDarkColors()
+                    ? window.ContextBridge.themeShouldUseDarkColors()
                         ? "filled-darker"
                         : "filled-lighter"
                     : searchBarAppearance

--- a/src/renderer/Core/Search/SearchHistoryController.ts
+++ b/src/renderer/Core/Search/SearchHistoryController.ts
@@ -1,16 +1,15 @@
 import { useSetting } from "@Core/Hooks";
-import type { ContextBridge } from "@common/Core";
 import { useState } from "react";
 
-export const useSearchHistoryController = ({ contextBridge }: { contextBridge: ContextBridge }) => {
-    const isEnabled = () => contextBridge.getSettingValue("general.searchHistory.enabled", false);
+export const useSearchHistoryController = () => {
+    const isEnabled = () => window.ContextBridge.getSettingValue("general.searchHistory.enabled", false);
 
     const { value: searchHistory, updateValue: setSearchHistory } = useSetting<string[]>({
         key: "general.searchHistory.history",
         defaultValue: [],
     });
 
-    const limit = contextBridge.getSettingValue("general.searchHistory.limit", 10);
+    const limit = window.ContextBridge.getSettingValue("general.searchHistory.limit", 10);
 
     const [menuIsOpen, setMenuIsOpen] = useState(false);
 

--- a/src/renderer/Core/Search/SearchViewController.ts
+++ b/src/renderer/Core/Search/SearchViewController.ts
@@ -1,5 +1,5 @@
 import { useSetting } from "@Core/Hooks";
-import type { ContextBridge, SearchResultItem, SearchResultItemAction } from "@common/Core";
+import type { SearchResultItem, SearchResultItemAction } from "@common/Core";
 import type { SearchEngineId } from "@common/Core/Search";
 import { useRef, useState } from "react";
 import { getNextSearchResultItemId } from "./Helpers/getNextSearchResultItemId";
@@ -13,7 +13,6 @@ type ViewModel = {
 };
 
 type SearchViewControllerProps = {
-    contextBridge: ContextBridge;
     searchResultItems: SearchResultItem[];
     excludedSearchResultItemIds: string[];
     favoriteSearchResultItemIds: string[];
@@ -30,7 +29,6 @@ const collectSearchResultItems = (searchResult: Record<string, SearchResultItem[
 };
 
 export const useSearchViewController = ({
-    contextBridge,
     searchResultItems,
     excludedSearchResultItemIds,
     favoriteSearchResultItemIds,
@@ -73,7 +71,7 @@ export const useSearchViewController = ({
             excludedSearchResultItemIds,
             favoriteSearchResultItemIds,
             fuzziness,
-            instantSearchResultItems: contextBridge.getInstantSearchResultItems(searchTerm),
+            instantSearchResultItems: window.ContextBridge.getInstantSearchResultItems(searchTerm),
             maxSearchResultItems,
             searchResultItems,
             searchTerm,
@@ -105,7 +103,7 @@ export const useSearchViewController = ({
 
     const invokeAction = async (action: SearchResultItemAction) => {
         if (!action.requiresConfirmation) {
-            await contextBridge.invokeAction(action);
+            await window.ContextBridge.invokeAction(action);
             return;
         }
 

--- a/src/renderer/Core/Settings/Navigation.tsx
+++ b/src/renderer/Core/Settings/Navigation.tsx
@@ -1,4 +1,3 @@
-import { useContextBridge } from "@Core/Hooks";
 import { getImageUrl } from "@Core/getImageUrl";
 import type { ExtensionInfo } from "@common/Core";
 import { Tab, TabList } from "@fluentui/react-components";
@@ -13,7 +12,6 @@ type NavigationProps = {
 
 export const Navigation = ({ settingsPages, enabledExtensions }: NavigationProps) => {
     const { t } = useTranslation();
-    const { contextBridge } = useContextBridge();
     const navigate = useNavigate();
     const { pathname } = useLocation();
 
@@ -61,7 +59,7 @@ export const Navigation = ({ settingsPages, enabledExtensions }: NavigationProps
                                 style={{ maxWidth: "100%", maxHeight: "100%" }}
                                 src={getImageUrl({
                                     image: e.image,
-                                    shouldPreferDarkColors: contextBridge.themeShouldUseDarkColors(),
+                                    shouldPreferDarkColors: window.ContextBridge.themeShouldUseDarkColors(),
                                 })}
                             />
                         </div>

--- a/src/renderer/Core/Settings/Pages/About.tsx
+++ b/src/renderer/Core/Settings/Pages/About.tsx
@@ -1,12 +1,9 @@
-import { useContextBridge } from "../../Hooks";
 import { Setting } from "../Setting";
 import { SettingGroup } from "../SettingGroup";
 import { SettingGroupList } from "../SettingGroupList";
 
 export const About = () => {
-    const { contextBridge } = useContextBridge();
-
-    const { electronVersion, nodeJsVersion, v8Version, version } = contextBridge.getAboutUeli();
+    const { electronVersion, nodeJsVersion, v8Version, version } = window.ContextBridge.getAboutUeli();
 
     return (
         <SettingGroupList>

--- a/src/renderer/Core/Settings/Pages/Appearance/Appearance.tsx
+++ b/src/renderer/Core/Settings/Pages/Appearance/Appearance.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useSetting } from "@Core/Hooks";
+import { useSetting } from "@Core/Hooks";
 import { getAvailableThemes, getTheme } from "@Core/Theme";
 import { darkTheme, lightTheme } from "@Core/Theme/defaultValues";
 import { ThemeContext } from "@Core/ThemeContext";
@@ -15,7 +15,6 @@ import { SearchBarSettings } from "./SearchBarSettings";
 
 export const Appearance = () => {
     const { t } = useTranslation("settingsAppearance");
-    const { contextBridge } = useContextBridge();
     const { setTheme } = useContext(ThemeContext);
 
     const availableThemes = getAvailableThemes();
@@ -43,27 +42,27 @@ export const Appearance = () => {
 
     const updateTheme = (themeName: string) => {
         setThemeName(themeName);
-        setTheme(getTheme(contextBridge));
+        setTheme(getTheme(window.ContextBridge));
     };
 
     const resetDarkVariants = () => {
         setDarkVariants(darkTheme);
-        setTheme(getTheme(contextBridge));
+        setTheme(getTheme(window.ContextBridge));
     };
 
     const updateDarkVariants = (shade: keyof BrandVariants, value: string) => {
         setDarkVariants({ ...darkVariants, ...{ [shade]: value } });
-        setTheme(getTheme(contextBridge));
+        setTheme(getTheme(window.ContextBridge));
     };
 
     const resetLightVariants = () => {
         setLightVariants(lightTheme);
-        setTheme(getTheme(contextBridge));
+        setTheme(getTheme(window.ContextBridge));
     };
 
     const updateLightVariants = (shade: keyof BrandVariants, value: string) => {
         setLightVariants({ ...lightVariants, ...{ [shade]: value } });
-        setTheme(getTheme(contextBridge));
+        setTheme(getTheme(window.ContextBridge));
     };
 
     return (

--- a/src/renderer/Core/Settings/Pages/Debug/Logs.tsx
+++ b/src/renderer/Core/Settings/Pages/Debug/Logs.tsx
@@ -1,20 +1,18 @@
-import { useContextBridge } from "@Core/Hooks";
 import { ThemeContext } from "@Core/ThemeContext";
 import { useContext, useEffect, useState } from "react";
 
 export const Logs = () => {
-    const { contextBridge } = useContextBridge();
     const { theme } = useContext(ThemeContext);
 
-    const [logs, setLogs] = useState<string[]>(contextBridge.getLogs());
+    const [logs, setLogs] = useState<string[]>(window.ContextBridge.getLogs());
 
     useEffect(() => {
-        const logsUpdatedEventHandler = () => setLogs(contextBridge.getLogs());
+        const logsUpdatedEventHandler = () => setLogs(window.ContextBridge.getLogs());
 
-        contextBridge.ipcRenderer.on("logsUpdated", logsUpdatedEventHandler);
+        window.ContextBridge.ipcRenderer.on("logsUpdated", logsUpdatedEventHandler);
 
         return () => {
-            contextBridge.ipcRenderer.off("logsUpdated", logsUpdatedEventHandler);
+            window.ContextBridge.ipcRenderer.off("logsUpdated", logsUpdatedEventHandler);
         };
     });
 

--- a/src/renderer/Core/Settings/Pages/Debug/ResetSettings.tsx
+++ b/src/renderer/Core/Settings/Pages/Debug/ResetSettings.tsx
@@ -1,4 +1,3 @@
-import { useContextBridge } from "@Core/Hooks";
 import {
     Button,
     Dialog,
@@ -14,7 +13,6 @@ import { useTranslation } from "react-i18next";
 
 export const ResetSettings = () => {
     const { t } = useTranslation("settingsDebug");
-    const { contextBridge } = useContextBridge();
 
     return (
         <Field label={t("resetAllSettings")} hint={t("resetAllSettingsHint")}>
@@ -36,7 +34,7 @@ export const ResetSettings = () => {
                             <DialogTrigger disableButtonEnhancement>
                                 <Button appearance="secondary">{t("resetAllSettingsCancel")}</Button>
                             </DialogTrigger>
-                            <Button onClick={() => contextBridge.resetAllSettings()} appearance="primary">
+                            <Button onClick={() => window.ContextBridge.resetAllSettings()} appearance="primary">
                                 {t("resetAllSettingsConfirm")}
                             </Button>
                         </DialogActions>

--- a/src/renderer/Core/Settings/Pages/Extensions.tsx
+++ b/src/renderer/Core/Settings/Pages/Extensions.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useSetting } from "@Core/Hooks";
+import { useSetting } from "@Core/Hooks";
 import { getImageUrl } from "@Core/getImageUrl";
 import {
     Avatar,
@@ -24,7 +24,6 @@ import { useTranslation } from "react-i18next";
 
 export const Extensions = () => {
     const { t } = useTranslation();
-    const { contextBridge } = useContextBridge();
     const toasterId = useId("rescanToasterId");
     const { dispatchToast } = useToastController(toasterId);
 
@@ -32,7 +31,7 @@ export const Extensions = () => {
         getAvailableExtensions,
         extensionDisabled: disableExtension,
         extensionEnabled: enableExtension,
-    } = contextBridge;
+    } = window.ContextBridge;
 
     const { value: enabledExtensionIds, updateValue: setEnabledExtensionIds } = useSetting({
         key: "extensions.enabledExtensionIds",
@@ -53,8 +52,8 @@ export const Extensions = () => {
 
     const triggerExtensionRescan = async (event: MouseEvent, extensionId: string) => {
         event.preventDefault();
-        await contextBridge.triggerExtensionRescan(extensionId);
-        const { name, nameTranslation } = contextBridge.getExtension(extensionId);
+        await window.ContextBridge.triggerExtensionRescan(extensionId);
+        const { name, nameTranslation } = window.ContextBridge.getExtension(extensionId);
 
         dispatchToast(
             <Toast>
@@ -104,7 +103,7 @@ export const Extensions = () => {
                                                     src={getImageUrl({
                                                         image,
                                                         shouldPreferDarkColors:
-                                                            contextBridge.themeShouldUseDarkColors(),
+                                                            window.ContextBridge.themeShouldUseDarkColors(),
                                                     })}
                                                 />
                                             </div>
@@ -122,7 +121,7 @@ export const Extensions = () => {
                                             appearance="subtle"
                                             onClick={async (e) => {
                                                 e.preventDefault();
-                                                await contextBridge.openExternal(
+                                                await window.ContextBridge.openExternal(
                                                     `https://github.com/${author.githubUserName}`,
                                                 );
                                             }}

--- a/src/renderer/Core/Settings/Pages/Favorites.tsx
+++ b/src/renderer/Core/Settings/Pages/Favorites.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useFavorites, useSearchResultItems } from "@Core/Hooks";
+import { useFavorites, useSearchResultItems } from "@Core/Hooks";
 import { SettingGroupList } from "@Core/Settings/SettingGroupList";
 import { getImageUrl } from "@Core/getImageUrl";
 import { Badge, Button, Input, Text, Tooltip } from "@fluentui/react-components";
@@ -7,13 +7,12 @@ import { useTranslation } from "react-i18next";
 import { SettingGroup } from "../SettingGroup";
 
 export const Favorites = () => {
-    const { contextBridge } = useContextBridge();
     const { t } = useTranslation("settingsFavorites");
     const { searchResultItems } = useSearchResultItems();
     const { favorites } = useFavorites();
 
     const removeFavorite = async (id: string) => {
-        await contextBridge.removeFavorite(id);
+        await window.ContextBridge.removeFavorite(id);
     };
 
     const favoriteSearchResultItems = searchResultItems.filter((s) => favorites.includes(s.id));
@@ -36,7 +35,7 @@ export const Favorites = () => {
                                         style={{ maxWidth: "100%", maxHeight: "100%" }}
                                         src={getImageUrl({
                                             image: s.image,
-                                            shouldPreferDarkColors: contextBridge.themeShouldUseDarkColors(),
+                                            shouldPreferDarkColors: window.ContextBridge.themeShouldUseDarkColors(),
                                         })}
                                     />
                                 </div>

--- a/src/renderer/Core/Settings/Pages/General/Autostart.tsx
+++ b/src/renderer/Core/Settings/Pages/General/Autostart.tsx
@@ -1,4 +1,3 @@
-import { useContextBridge } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { Switch } from "@fluentui/react-components";
 import { useState } from "react";
@@ -6,12 +5,11 @@ import { useTranslation } from "react-i18next";
 
 export const Autostart = () => {
     const { t } = useTranslation("settingsGeneral");
-    const { contextBridge } = useContextBridge();
 
-    const [autostartIsEnabled, setAutostartIsEnabled] = useState<boolean>(contextBridge.autostartIsEnabled());
+    const [autostartIsEnabled, setAutostartIsEnabled] = useState<boolean>(window.ContextBridge.autostartIsEnabled());
 
     const updateAutostartSettings = (autostartIsEnabled: boolean) => {
-        contextBridge.autostartSettingsChanged(autostartIsEnabled);
+        window.ContextBridge.autostartSettingsChanged(autostartIsEnabled);
         setAutostartIsEnabled(autostartIsEnabled);
     };
 

--- a/src/renderer/Core/Settings/Pages/General/DockSettings.tsx
+++ b/src/renderer/Core/Settings/Pages/General/DockSettings.tsx
@@ -1,11 +1,10 @@
-import { useContextBridge, useSetting } from "@Core/Hooks";
+import { useSetting } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { Switch } from "@fluentui/react-components";
 import { useTranslation } from "react-i18next";
 
 export const DockSettings = () => {
     const { t } = useTranslation("settingsGeneral");
-    const { contextBridge } = useContextBridge();
 
     const { value: showAppIconInDock, updateValue: setShowAppIconInDock } = useSetting<boolean>({
         key: "appearance.showAppIconInDock",
@@ -13,7 +12,7 @@ export const DockSettings = () => {
     });
 
     const updateShowAppIconInDock = async (value: boolean) => {
-        await contextBridge.updateSettingValue("appearance.showAppIconInDock", value);
+        await window.ContextBridge.updateSettingValue("appearance.showAppIconInDock", value);
         setShowAppIconInDock(value);
     };
 

--- a/src/renderer/Core/Settings/Pages/General/HotKey.tsx
+++ b/src/renderer/Core/Settings/Pages/General/HotKey.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useSetting } from "@Core/Hooks";
+import { useSetting } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { isValidHotkey } from "@common/Core/Hotkey";
 import { Button, Field, Input, Tooltip } from "@fluentui/react-components";
@@ -8,8 +8,6 @@ import { useTranslation } from "react-i18next";
 
 export const HotKey = () => {
     const { t } = useTranslation("settingsGeneral");
-
-    const { contextBridge } = useContextBridge();
 
     const { value: hotkey, updateValue: setHotkey } = useSetting({ key: "general.hotkey", defaultValue: "Alt+Space" });
 
@@ -36,7 +34,7 @@ export const HotKey = () => {
                                     size="small"
                                     icon={<InfoRegular />}
                                     onClick={() =>
-                                        contextBridge.openExternal(
+                                        window.ContextBridge.openExternal(
                                             "https://www.electronjs.org/docs/latest/api/accelerator",
                                         )
                                     }

--- a/src/renderer/Core/Settings/Pages/SearchEngine/ExcludedItems.tsx
+++ b/src/renderer/Core/Settings/Pages/SearchEngine/ExcludedItems.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useSearchResultItems } from "@Core/Hooks";
+import { useSearchResultItems } from "@Core/Hooks";
 import { getImageUrl } from "@Core/getImageUrl";
 import { Badge, Button, Input, Text, Tooltip } from "@fluentui/react-components";
 import { DismissRegular } from "@fluentui/react-icons";
@@ -7,14 +7,13 @@ import { useTranslation } from "react-i18next";
 
 export const ExcludedItems = () => {
     const { t } = useTranslation("settingsSearchEngine");
-    const { contextBridge } = useContextBridge();
     const { searchResultItems } = useSearchResultItems();
 
-    const [excludedIds, setExcludedIds] = useState<string[]>(contextBridge.getExcludedSearchResultItemIds());
+    const [excludedIds, setExcludedIds] = useState<string[]>(window.ContextBridge.getExcludedSearchResultItemIds());
 
     const removeExcludedSearchResultItem = async (id: string) => {
-        await contextBridge.removeExcludedSearchResultItem(id);
-        setExcludedIds(contextBridge.getExcludedSearchResultItemIds());
+        await window.ContextBridge.removeExcludedSearchResultItem(id);
+        setExcludedIds(window.ContextBridge.getExcludedSearchResultItemIds());
     };
 
     const excludedSearchResultItems = searchResultItems.filter((f) => excludedIds.includes(f.id));
@@ -33,7 +32,7 @@ export const ExcludedItems = () => {
                             style={{ width: 16, height: 16 }}
                             src={getImageUrl({
                                 image,
-                                shouldPreferDarkColors: contextBridge.themeShouldUseDarkColors(),
+                                shouldPreferDarkColors: window.ContextBridge.themeShouldUseDarkColors(),
                             })}
                         />
                     }

--- a/src/renderer/Core/Settings/Pages/SearchEngine/RescanInterval.tsx
+++ b/src/renderer/Core/Settings/Pages/SearchEngine/RescanInterval.tsx
@@ -1,4 +1,3 @@
-import { useContextBridge } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { Button, Input, Tooltip } from "@fluentui/react-components";
 import { DismissRegular } from "@fluentui/react-icons";
@@ -11,11 +10,10 @@ type RescanIntervalProps = {
 
 export const RescanInterval = ({ automaticRescanEnabled }: RescanIntervalProps) => {
     const { t } = useTranslation("settingsSearchEngine");
-    const { contextBridge } = useContextBridge();
 
     const defaultRescanIntervalInSeconds = 300;
 
-    const rescanIntervalInSeconds = contextBridge.getSettingValue(
+    const rescanIntervalInSeconds = window.ContextBridge.getSettingValue(
         "searchEngine.rescanIntervalInSeconds",
         defaultRescanIntervalInSeconds,
     );
@@ -23,7 +21,7 @@ export const RescanInterval = ({ automaticRescanEnabled }: RescanIntervalProps) 
     const [tempRescanIntervalInSeconds, setTempRescanIntervalInSeconds] = useState<number>(rescanIntervalInSeconds);
 
     const setRescanIntervalInSeconds = (value: number) =>
-        contextBridge.updateSettingValue("searchEngine.rescanIntervalInSeconds", value);
+        window.ContextBridge.updateSettingValue("searchEngine.rescanIntervalInSeconds", value);
 
     return (
         <Setting

--- a/src/renderer/Core/Settings/Pages/Window/Window.tsx
+++ b/src/renderer/Core/Settings/Pages/Window/Window.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useSetting } from "@Core/Hooks";
+import { useSetting } from "@Core/Hooks";
 import { SettingGroup } from "@Core/Settings/SettingGroup";
 import { SettingGroupList } from "../../SettingGroupList";
 import { AlwaysOnTop } from "./AlwaysOnTop";
@@ -11,9 +11,7 @@ import { Vibrancy } from "./Vibrancy";
 import { WorkspaceVisibility } from "./WorkspaceVisibility";
 
 export const Window = () => {
-    const { contextBridge } = useContextBridge();
-
-    const operatingSystem = contextBridge.getOperatingSystem();
+    const operatingSystem = window.ContextBridge.getOperatingSystem();
 
     const { value: backgroundMaterial, updateValue: setBackgroundMaterial } = useSetting({
         key: "window.backgroundMaterial",

--- a/src/renderer/Core/Settings/Pages/Window/WorkspaceVisibility.tsx
+++ b/src/renderer/Core/Settings/Pages/Window/WorkspaceVisibility.tsx
@@ -1,19 +1,17 @@
-import { useContextBridge } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { Switch } from "@fluentui/react-components";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export const WorkspaceVisibility = () => {
-    const { contextBridge } = useContextBridge();
     const { t } = useTranslation("settingsWindow");
 
     const [visibleOnAllWorkspaces, setVisibleOnAllWorkspaces] = useState<boolean>(
-        contextBridge.getSettingValue("window.visibleOnAllWorkspaces", false),
+        window.ContextBridge.getSettingValue("window.visibleOnAllWorkspaces", false),
     );
 
     const updateVisibleOnAllWorkspaces = async (value: boolean) => {
-        await contextBridge.updateSettingValue("window.visibleOnAllWorkspaces", value);
+        await window.ContextBridge.updateSettingValue("window.visibleOnAllWorkspaces", value);
         setVisibleOnAllWorkspaces(value);
     };
 

--- a/src/renderer/Core/Settings/Settings.tsx
+++ b/src/renderer/Core/Settings/Settings.tsx
@@ -1,4 +1,3 @@
-import { useContextBridge } from "@Core/Hooks";
 import type { KeyboardEvent } from "react";
 import { Route, Routes, useNavigate } from "react-router";
 import { ExtensionSettings } from "./ExtensionSettings";
@@ -7,7 +6,6 @@ import { settingsPages } from "./Pages";
 import { SettingsHeader } from "./SettingsHeader";
 
 export const Settings = () => {
-    const { contextBridge } = useContextBridge();
     const navigate = useNavigate();
     const closeSettings = () => navigate({ pathname: "/" });
 
@@ -53,7 +51,7 @@ export const Settings = () => {
                     >
                         <Navigation
                             settingsPages={settingsPages}
-                            enabledExtensions={contextBridge.getEnabledExtensions()}
+                            enabledExtensions={window.ContextBridge.getEnabledExtensions()}
                         />
                     </div>
                 </div>

--- a/src/renderer/Core/useAppCssProperties.ts
+++ b/src/renderer/Core/useAppCssProperties.ts
@@ -1,6 +1,5 @@
 import type { ContextBridge, OperatingSystem } from "@common/Core";
 import { useEffect, useState, type CSSProperties } from "react";
-import { useContextBridge } from "./Hooks";
 
 const getMacOsCssProperties = (contextBridge: ContextBridge): CSSProperties => {
     return contextBridge.getSettingValue<string>("window.vibrancy", "None") === "None"
@@ -25,16 +24,14 @@ const getWindowsCssProperties = (contextBridge: ContextBridge): CSSProperties =>
 };
 
 export const useAppCssProperties = () => {
-    const { contextBridge } = useContextBridge();
-
-    const operatingSystem = contextBridge.getOperatingSystem();
+    const operatingSystem = window.ContextBridge.getOperatingSystem();
 
     const extendGlobalStyles = (cssProperties: CSSProperties) => ({ height: "100vh", ...cssProperties });
 
     const initialProperties: Record<OperatingSystem, CSSProperties> = {
         Linux: extendGlobalStyles({}),
-        macOS: extendGlobalStyles(getMacOsCssProperties(contextBridge)),
-        Windows: extendGlobalStyles(getWindowsCssProperties(contextBridge)),
+        macOS: extendGlobalStyles(getMacOsCssProperties(window.ContextBridge)),
+        Windows: extendGlobalStyles(getWindowsCssProperties(window.ContextBridge)),
     };
 
     const [appCssProperties, setAppCssProperties] = useState<CSSProperties>(initialProperties[operatingSystem]);
@@ -42,8 +39,8 @@ export const useAppCssProperties = () => {
     useEffect(() => {
         const eventHandlers: Record<OperatingSystem, () => void> = {
             Linux: () => null,
-            macOS: () => setAppCssProperties(extendGlobalStyles(getMacOsCssProperties(contextBridge))),
-            Windows: () => setAppCssProperties(extendGlobalStyles(getWindowsCssProperties(contextBridge))),
+            macOS: () => setAppCssProperties(extendGlobalStyles(getMacOsCssProperties(window.ContextBridge))),
+            Windows: () => setAppCssProperties(extendGlobalStyles(getWindowsCssProperties(window.ContextBridge))),
         };
 
         const channels: Record<OperatingSystem, string[]> = {
@@ -58,13 +55,13 @@ export const useAppCssProperties = () => {
 
         const registerEventListeners = () => {
             for (const channel of channels[operatingSystem]) {
-                contextBridge.ipcRenderer.on(channel, eventHandlers[operatingSystem]);
+                window.ContextBridge.ipcRenderer.on(channel, eventHandlers[operatingSystem]);
             }
         };
 
         const unregisterEventListeners = () => {
             for (const channel of channels[operatingSystem]) {
-                contextBridge.ipcRenderer.off(channel, eventHandlers[operatingSystem]);
+                window.ContextBridge.ipcRenderer.off(channel, eventHandlers[operatingSystem]);
             }
         };
 

--- a/src/renderer/Extensions/ApplicationSearch/ApplicationSearchSettings.tsx
+++ b/src/renderer/Extensions/ApplicationSearch/ApplicationSearchSettings.tsx
@@ -1,4 +1,3 @@
-import { useContextBridge } from "@Core/Hooks";
 import type { OperatingSystem } from "@common/Core";
 import type { ReactElement } from "react";
 import { LinuxSettings } from "./Linux";
@@ -6,15 +5,11 @@ import { MacOsSettings } from "./MacOs";
 import { WindowsSettings } from "./Windows";
 
 export const ApplicationSearchSettings = () => {
-    const { contextBridge } = useContextBridge();
-
-    const operatingSystem = contextBridge.getOperatingSystem();
-
     const settings: Record<OperatingSystem, ReactElement> = {
         Linux: <LinuxSettings />,
         macOS: <MacOsSettings />,
         Windows: <WindowsSettings />,
     };
 
-    return settings[operatingSystem];
+    return settings[window.ContextBridge.getOperatingSystem()];
 };

--- a/src/renderer/Extensions/ApplicationSearch/Linux/LinuxSettings.tsx
+++ b/src/renderer/Extensions/ApplicationSearch/Linux/LinuxSettings.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useExtensionSetting } from "@Core/Hooks";
+import { useExtensionSetting } from "@Core/Hooks";
 import { SettingGroup } from "@Core/Settings/SettingGroup";
 import { SettingGroupList } from "@Core/Settings/SettingGroupList";
 import { Button, Input, Tooltip } from "@fluentui/react-components";
@@ -6,8 +6,6 @@ import { AddRegular, DismissRegular, FolderRegular } from "@fluentui/react-icons
 import { useState } from "react";
 
 export const LinuxSettings = () => {
-    const { contextBridge } = useContextBridge();
-
     const extensionId = "ApplicationSearch";
 
     const [newFolder, setNewFolder] = useState<string>("");
@@ -29,7 +27,7 @@ export const LinuxSettings = () => {
     };
 
     const chooseFolder = async () => {
-        const result = await contextBridge.showOpenDialog({ properties: ["openDirectory"] });
+        const result = await window.ContextBridge.showOpenDialog({ properties: ["openDirectory"] });
         if (!result.canceled && result.filePaths.length) {
             setNewFolder(result.filePaths[0]);
         }

--- a/src/renderer/Extensions/ApplicationSearch/MacOs/MacOsSettings.tsx
+++ b/src/renderer/Extensions/ApplicationSearch/MacOs/MacOsSettings.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useExtensionSetting } from "@Core/Hooks";
+import { useExtensionSetting } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { SettingGroup } from "@Core/Settings/SettingGroup";
 import { SettingGroupList } from "@Core/Settings/SettingGroupList";
@@ -8,8 +8,6 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 export const MacOsSettings = () => {
-    const { contextBridge } = useContextBridge();
-
     const extensionId = "ApplicationSearch";
 
     const [newFolder, setNewFolder] = useState<string>("");
@@ -38,7 +36,7 @@ export const MacOsSettings = () => {
     };
 
     const chooseFolder = async () => {
-        const result = await contextBridge.showOpenDialog({ properties: ["openDirectory"] });
+        const result = await window.ContextBridge.showOpenDialog({ properties: ["openDirectory"] });
         if (!result.canceled && result.filePaths.length) {
             setNewFolder(result.filePaths[0]);
         }

--- a/src/renderer/Extensions/ApplicationSearch/Windows/Folders.tsx
+++ b/src/renderer/Extensions/ApplicationSearch/Windows/Folders.tsx
@@ -1,11 +1,9 @@
-import { useContextBridge, useExtensionSetting } from "@Core/Hooks";
+import { useExtensionSetting } from "@Core/Hooks";
 import { Button, Input, Tooltip } from "@fluentui/react-components";
 import { AddRegular, DismissRegular, FolderRegular } from "@fluentui/react-icons";
 import { useState } from "react";
 
 export const Folders = () => {
-    const { contextBridge } = useContextBridge();
-
     const { value: folders, updateValue: setFolders } = useExtensionSetting<string[]>({
         extensionId: "ApplicationSearch",
         key: "windowsFolders",
@@ -23,7 +21,7 @@ export const Folders = () => {
     };
 
     const chooseFolder = async () => {
-        const result = await contextBridge.showOpenDialog({ properties: ["openDirectory"] });
+        const result = await window.ContextBridge.showOpenDialog({ properties: ["openDirectory"] });
         if (!result.canceled && result.filePaths.length) {
             setNewFolder(result.filePaths[0]);
         }

--- a/src/renderer/Extensions/Base64Conversion/Converter.tsx
+++ b/src/renderer/Extensions/Base64Conversion/Converter.tsx
@@ -1,5 +1,4 @@
 import type { InvocationArgument } from "@common/Extensions/Base64Conversion";
-import { useContextBridge } from "@Core/Hooks";
 import { Textarea } from "@fluentui/react-components";
 import { useEffect, useState } from "react";
 
@@ -11,13 +10,12 @@ type ConverterProps = {
 
 export const Converter = ({ setConvertedText, encodePlaceholder, decodePlaceholder }: ConverterProps) => {
     const extensionId = "Base64Conversion";
-    const { contextBridge } = useContextBridge();
     const [input, setInput] = useState<InvocationArgument>({ payload: "", action: "encode" });
     const [conversionResult, setConversionResult] = useState("");
 
     const convertText = async (payload: string, action: "encode" | "decode") => {
         try {
-            return await contextBridge.invokeExtension<InvocationArgument, string>(extensionId, {
+            return await window.ContextBridge.invokeExtension<InvocationArgument, string>(extensionId, {
                 payload,
                 action,
             });

--- a/src/renderer/Extensions/BrowserBookmarks/BrowserBookmarksSettings.tsx
+++ b/src/renderer/Extensions/BrowserBookmarks/BrowserBookmarksSettings.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useExtensionSetting } from "@Core/Hooks";
+import { useExtensionSetting } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { SettingGroup } from "@Core/Settings/SettingGroup";
 import { SettingGroupList } from "@Core/Settings/SettingGroupList";
@@ -8,7 +8,6 @@ import { useTranslation } from "react-i18next";
 
 export const BrowserBookmarksSettings = () => {
     const { t } = useTranslation("extension[BrowserBookmarks]");
-    const { contextBridge } = useContextBridge();
 
     const extensionId = "BrowserBookmarks";
 
@@ -56,7 +55,7 @@ export const BrowserBookmarksSettings = () => {
                                     <img
                                         style={{ width: 20, height: 20 }}
                                         alt={browserName}
-                                        src={`file://${contextBridge.getExtensionAssetFilePath(extensionId, browserName)}`}
+                                        src={`file://${window.ContextBridge.getExtensionAssetFilePath(extensionId, browserName)}`}
                                     />
                                     {browserName}
                                 </Option>

--- a/src/renderer/Extensions/FileSearch/FileSearchSettings.tsx
+++ b/src/renderer/Extensions/FileSearch/FileSearchSettings.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useExtensionSetting } from "@Core/Hooks";
+import { useExtensionSetting } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { SettingGroup } from "@Core/Settings/SettingGroup";
 import { SettingGroupList } from "@Core/Settings/SettingGroupList";
@@ -8,7 +8,6 @@ import { useTranslation } from "react-i18next";
 
 export const FileSearchSettings = () => {
     const { t } = useTranslation("extension[FileSearch]");
-    const { contextBridge } = useContextBridge();
 
     const { value: maxSearchResultCount, updateValue: setMaxSearchResultCount } = useExtensionSetting<number>({
         extensionId: "FileSearch",
@@ -21,7 +20,7 @@ export const FileSearchSettings = () => {
     });
 
     const chooseFile = async () => {
-        const result = await contextBridge.showOpenDialog({ properties: ["openFile"] });
+        const result = await window.ContextBridge.showOpenDialog({ properties: ["openFile"] });
         if (!result.canceled && result.filePaths.length > 0) {
             setEsFilePath(result.filePaths[0]);
         }
@@ -40,10 +39,10 @@ export const FileSearchSettings = () => {
                         />
                     }
                 />
-                {contextBridge.getOperatingSystem() === "Windows" && (
+                {window.ContextBridge.getOperatingSystem() === "Windows" && (
                     <Setting
                         label={t("esFilePath")}
-                        description={contextBridge.fileExists(esFilePath) ? undefined : t("fileDoesNotExist")}
+                        description={window.ContextBridge.fileExists(esFilePath) ? undefined : t("fileDoesNotExist")}
                         control={
                             <div style={{ display: "flex", flexDirection: "column", width: "80%" }}>
                                 <Input

--- a/src/renderer/Extensions/SimpleFileSearch/EditFolder.tsx
+++ b/src/renderer/Extensions/SimpleFileSearch/EditFolder.tsx
@@ -1,5 +1,4 @@
 import type { FolderSetting } from "@common/Extensions/SimpleFileSearch";
-import { useContextBridge } from "@Core/Hooks";
 import {
     Button,
     Checkbox,
@@ -42,8 +41,6 @@ const mapTemporaryFolderSettingToFolderSetting = ({
 export const EditFolder = ({ initialFolderSetting, onSave }: EditFolderProps) => {
     const { t } = useTranslation("extension[SimpleFileSearch]");
 
-    const { contextBridge } = useContextBridge();
-
     const [isDialogOpen, setIsDialogOpen] = useState(false);
 
     const [temporaryFolderSetting, setTemporaryFolderSetting] = useState<TemporaryFolderSetting>(initialFolderSetting);
@@ -56,14 +53,18 @@ export const EditFolder = ({ initialFolderSetting, onSave }: EditFolderProps) =>
     };
 
     const openFileDialog = async () => {
-        const result = await contextBridge.showOpenDialog({ properties: ["openDirectory"] });
+        const result = await window.ContextBridge.showOpenDialog({ properties: ["openDirectory"] });
         if (!result.canceled && result.filePaths.length) {
             setPath(result.filePaths[0]);
         }
     };
 
     const setPath = (path: string) => {
-        setTemporaryFolderSetting({ ...temporaryFolderSetting, path, isValidPath: contextBridge.fileExists(path) });
+        setTemporaryFolderSetting({
+            ...temporaryFolderSetting,
+            path,
+            isValidPath: window.ContextBridge.fileExists(path),
+        });
     };
 
     const setRecursive = (recursive: boolean) => setTemporaryFolderSetting({ ...temporaryFolderSetting, recursive });

--- a/src/renderer/Extensions/TerminalLauncher/TerminalLauncherSettings.tsx
+++ b/src/renderer/Extensions/TerminalLauncher/TerminalLauncherSettings.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useExtensionSetting } from "@Core/Hooks";
+import { useExtensionSetting } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { SettingGroup } from "@Core/Settings/SettingGroup";
 import { SettingGroupList } from "@Core/Settings/SettingGroupList";
@@ -6,7 +6,6 @@ import { Dropdown, Input, Option } from "@fluentui/react-components";
 import { useTranslation } from "react-i18next";
 
 export const TerminalLauncherSettings = () => {
-    const { contextBridge } = useContextBridge();
     const { t } = useTranslation("extension[TerminalLauncher]");
 
     const extensionId = "TerminalLauncher";
@@ -18,7 +17,7 @@ export const TerminalLauncherSettings = () => {
         key: "terminalIds",
     });
 
-    const availableTerminals = contextBridge.getAvailableTerminals();
+    const availableTerminals = window.ContextBridge.getAvailableTerminals();
 
     return (
         <SettingGroupList>

--- a/src/renderer/Extensions/WebSearch/WebSearchSettings.tsx
+++ b/src/renderer/Extensions/WebSearch/WebSearchSettings.tsx
@@ -1,4 +1,4 @@
-import { useContextBridge, useExtensionSetting } from "@Core/Hooks";
+import { useExtensionSetting } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { SettingGroup } from "@Core/Settings/SettingGroup";
 import { SettingGroupList } from "@Core/Settings/SettingGroupList";
@@ -6,7 +6,6 @@ import { Dropdown, Option, Switch } from "@fluentui/react-components";
 import { useTranslation } from "react-i18next";
 
 export const WebSearchSettings = () => {
-    const { contextBridge } = useContextBridge();
     const extensionId = "WebSearch";
 
     const { t } = useTranslation("extension[WebSearch]");
@@ -49,7 +48,7 @@ export const WebSearchSettings = () => {
                                         <img
                                             style={{ width: 16, height: 16 }}
                                             alt={searchEngine}
-                                            src={`file://${contextBridge.getExtensionAssetFilePath("WebSearch", searchEngine)}`}
+                                            src={`file://${window.ContextBridge.getExtensionAssetFilePath("WebSearch", searchEngine)}`}
                                         />
                                         {searchEngine}
                                     </div>

--- a/src/renderer/Extensions/Workflow/NewActionOpenFile.tsx
+++ b/src/renderer/Extensions/Workflow/NewActionOpenFile.tsx
@@ -1,4 +1,3 @@
-import { useContextBridge } from "@Core/Hooks";
 import type { OpenFileActionArgs } from "@common/Extensions/Workflow";
 import { Button, Field, Input } from "@fluentui/react-components";
 import { FolderRegular } from "@fluentui/react-icons";
@@ -6,7 +5,6 @@ import { useTranslation } from "react-i18next";
 import type { NewActionTypeProps } from "./NewActionTypeProps";
 
 export const NewActionOpenFile = ({ args, setArgs }: NewActionTypeProps) => {
-    const { contextBridge } = useContextBridge();
     const { t } = useTranslation("extension[Workflow]");
 
     const { filePath } = args as OpenFileActionArgs;
@@ -14,7 +12,7 @@ export const NewActionOpenFile = ({ args, setArgs }: NewActionTypeProps) => {
     const setFilePath = (filePath: string) => setArgs({ filePath });
 
     const selectFile = async () => {
-        const result = await contextBridge.showOpenDialog({ properties: ["openFile"] });
+        const result = await window.ContextBridge.showOpenDialog({ properties: ["openFile"] });
         if (!result.canceled && result.filePaths.length > 0) {
             setFilePath(result.filePaths[0]);
         }

--- a/src/renderer/Extensions/Workflow/NewActionOpenTerminal.tsx
+++ b/src/renderer/Extensions/Workflow/NewActionOpenTerminal.tsx
@@ -1,11 +1,9 @@
-import { useContextBridge } from "@Core/Hooks";
 import type { OpenTerminalActionArgs } from "@common/Extensions/Workflow";
 import { Dropdown, Field, Input, Option } from "@fluentui/react-components";
 import { useTranslation } from "react-i18next";
 import type { NewActionTypeProps } from "./NewActionTypeProps";
 
 export const NewActionOpenTerminal = ({ args, setArgs }: NewActionTypeProps) => {
-    const { contextBridge } = useContextBridge();
     const { t } = useTranslation("extension[Workflow]");
 
     const { terminalId, command } = args as OpenTerminalActionArgs;
@@ -14,7 +12,7 @@ export const NewActionOpenTerminal = ({ args, setArgs }: NewActionTypeProps) => 
 
     const setCommand = (newCommand: string) => setArgs({ terminalId, command: newCommand });
 
-    const defaultTerminalId = contextBridge.getAvailableTerminals()[0]?.id;
+    const defaultTerminalId = window.ContextBridge.getAvailableTerminals()[0]?.id;
 
     return (
         <>
@@ -27,7 +25,7 @@ export const NewActionOpenTerminal = ({ args, setArgs }: NewActionTypeProps) => 
                     disabled={!terminalId}
                     size="small"
                 >
-                    {contextBridge.getAvailableTerminals().map(({ id, name, assetFilePath }) => (
+                    {window.ContextBridge.getAvailableTerminals().map(({ id, name, assetFilePath }) => (
                         <Option key={id} value={id} text={name}>
                             <img src={`file://${assetFilePath}`} alt={name} width={16} />
                             <span>{name}</span>


### PR DESCRIPTION
This PR removes the hook `useContextBridge` and replaces it directly with `window.ContextBridge`.