### PR TITLE
fix: Improve Linux app filtering

### DIFF
--- a/src/main/Extensions/ApplicationSearch/Linux/LinuxApplicationRepository.ts
+++ b/src/main/Extensions/ApplicationSearch/Linux/LinuxApplicationRepository.ts
@@ -95,7 +95,8 @@ export class LinuxApplicationRepository implements ApplicationRepository {
         if (
             (config.NoDisplay && config.NoDisplay.toLowerCase() === "true") ||
             (config.OnlyShowIn && !config.OnlyShowIn.split(";").some((i) => desktopEnv.includes(i))) ||
-            (config.NotShowIn && config.NotShowIn.split(";").some((i) => desktopEnv.includes(i)))
+            (config.NotShowIn && config.NotShowIn.split(";").some((i) => desktopEnv.includes(i))) ||
+            (config.Type && config.Type.toLocaleLowerCase() !== "application")
         ) {
             return undefined;
         }


### PR DESCRIPTION
Filters out any `.desktop` files not of type Application