### PR TITLE
Improve responsiveness of app launches

### DIFF
--- a/src/main/Core/CommandlineUtility/ActionHandler/CommandlineActionHandler.test.ts
+++ b/src/main/Core/CommandlineUtility/ActionHandler/CommandlineActionHandler.test.ts
@@ -1,14 +1,21 @@
 import type { SearchResultItemAction } from "@common/Core";
 import { describe, expect, it, vi } from "vitest";
+import type { BrowserWindowRegistry } from "../../BrowserWindowRegistry";
 import type { CommandlineUtility } from "../Contract";
 import { CommandlineActionHandler } from "./CommandlineActionHandler";
+
+const browserRegistryMock = {
+    getById: () => {
+        return { show: vi.fn(), hide: vi.fn() };
+    },
+} as unknown as BrowserWindowRegistry;
 
 describe(CommandlineActionHandler, () => {
     it("should execute commandline commands", async () => {
         const executeCommandMock = vi.fn();
         const commandlineUtility = <CommandlineUtility>{ executeCommand: (command) => executeCommandMock(command) };
 
-        const actionHandler = new CommandlineActionHandler(commandlineUtility);
+        const actionHandler = new CommandlineActionHandler(commandlineUtility, browserRegistryMock);
         await actionHandler.invokeAction(<SearchResultItemAction>{ argument: "command" });
 
         expect(actionHandler.id).toEqual("Commandline");

--- a/src/main/Core/CommandlineUtility/ActionHandler/CommandlineActionHandler.ts
+++ b/src/main/Core/CommandlineUtility/ActionHandler/CommandlineActionHandler.ts
@@ -1,5 +1,6 @@
 import type { SearchResultItemAction } from "@common/Core";
 import type { ActionHandler } from "@Core/ActionHandler";
+import type { BrowserWindowRegistry } from "../../BrowserWindowRegistry";
 import type { CommandlineUtility } from "../Contract";
 
 /**
@@ -8,7 +9,10 @@ import type { CommandlineUtility } from "../Contract";
 export class CommandlineActionHandler implements ActionHandler {
     public readonly id = "Commandline";
 
-    public constructor(private readonly commandlineUtility: CommandlineUtility) {}
+    public constructor(
+        private readonly commandlineUtility: CommandlineUtility,
+        private readonly browserRegistry: BrowserWindowRegistry,
+    ) {}
 
     /**
      * Executes the given CLI command and waits until it finishes.
@@ -16,6 +20,13 @@ export class CommandlineActionHandler implements ActionHandler {
      * Expects the given action's argument to be a valid CLI command, e.g.: `"ls -la"`.
      */
     public async invokeAction(action: SearchResultItemAction): Promise<void> {
-        await this.commandlineUtility.executeCommand(action.argument);
+        const searchWindow = this.browserRegistry.getById("search");
+
+        searchWindow?.hide();
+        try {
+            await this.commandlineUtility.executeCommand(action.argument);
+        } catch (err) {
+            searchWindow?.show();
+        }
     }
 }

--- a/src/main/Core/CommandlineUtility/CommandlineUtilityModule.test.ts
+++ b/src/main/Core/CommandlineUtility/CommandlineUtilityModule.test.ts
@@ -1,6 +1,7 @@
 import type { ActionHandlerRegistry } from "@Core/ActionHandler";
 import type { UeliModuleRegistry } from "@Core/ModuleRegistry";
 import { describe, expect, it, vi } from "vitest";
+import type { BrowserWindowRegistry } from "../BrowserWindowRegistry";
 import { CommandlineActionHandler } from "./ActionHandler";
 import { CommandlineUtilityModule } from "./CommandlineUtilityModule";
 import { NodeJsCommandlineUtility } from "./NodeJsCommandlineUtility";
@@ -13,8 +14,14 @@ describe(CommandlineUtilityModule, () => {
             getById: vi.fn(),
         };
 
+        const browserRegistryMock = {
+            getAll: vi.fn(),
+            getById: vi.fn(),
+            register: vi.fn(),
+        } as unknown as BrowserWindowRegistry;
+
         const moduleRegistry = <UeliModuleRegistry>{
-            get: vi.fn().mockReturnValue(actionHandlerRegistryMock),
+            get: vi.fn().mockReturnValueOnce(browserRegistryMock).mockReturnValueOnce(actionHandlerRegistryMock),
             register: vi.fn(),
         };
 
@@ -22,9 +29,10 @@ describe(CommandlineUtilityModule, () => {
 
         expect(moduleRegistry.register).toHaveBeenCalledWith("CommandlineUtility", new NodeJsCommandlineUtility());
 
-        expect(moduleRegistry.get).toBeCalledWith("ActionHandlerRegistry");
+        expect(moduleRegistry.get).toHaveBeenNthCalledWith(1, "BrowserWindowRegistry");
+        expect(moduleRegistry.get).toHaveBeenNthCalledWith(2, "ActionHandlerRegistry");
         expect(actionHandlerRegistryMock.register).toHaveBeenCalledWith(
-            new CommandlineActionHandler(new NodeJsCommandlineUtility()),
+            new CommandlineActionHandler(new NodeJsCommandlineUtility(), browserRegistryMock),
         );
     });
 });

--- a/src/main/Core/CommandlineUtility/CommandlineUtilityModule.ts
+++ b/src/main/Core/CommandlineUtility/CommandlineUtilityModule.ts
@@ -4,9 +4,13 @@ import { NodeJsCommandlineUtility } from "./NodeJsCommandlineUtility";
 
 export class CommandlineUtilityModule {
     public static bootstrap(moduleRegistry: UeliModuleRegistry) {
-        const commandlineUtility = new NodeJsCommandlineUtility();
+        const browserRegistry = moduleRegistry.get("BrowserWindowRegistry");
 
+        const commandlineUtility = new NodeJsCommandlineUtility();
         moduleRegistry.register("CommandlineUtility", commandlineUtility);
-        moduleRegistry.get("ActionHandlerRegistry").register(new CommandlineActionHandler(commandlineUtility));
+
+        moduleRegistry
+            .get("ActionHandlerRegistry")
+            .register(new CommandlineActionHandler(commandlineUtility, browserRegistry));
     }
 }

--- a/src/main/Extensions/ApplicationSearch/ApplicationSearchModule.ts
+++ b/src/main/Extensions/ApplicationSearch/ApplicationSearchModule.ts
@@ -49,7 +49,12 @@ export class ApplicationSearchModule implements ExtensionModule {
         };
 
         const actionHandlers: Record<OperatingSystem, () => ActionHandler[]> = {
-            Linux: () => [new LaunchDesktopFileActionHandler(moduleRegistry.get("CommandlineUtility"))],
+            Linux: () => [
+                new LaunchDesktopFileActionHandler(
+                    moduleRegistry.get("CommandlineUtility"),
+                    moduleRegistry.get("BrowserWindowRegistry"),
+                ),
+            ],
             macOS: () => [],
             Windows: () => [new OpenAsAdministrator(moduleRegistry.get("PowershellUtility"))],
         };

--- a/src/main/Extensions/ApplicationSearch/Linux/LaunchDesktopFileActionHandler.test.ts
+++ b/src/main/Extensions/ApplicationSearch/Linux/LaunchDesktopFileActionHandler.test.ts
@@ -1,14 +1,21 @@
 import type { CommandlineUtility } from "@Core/CommandlineUtility";
 import type { SearchResultItemAction } from "@common/Core";
 import { describe, expect, it, vi } from "vitest";
+import type { BrowserWindowRegistry } from "../../../Core";
 import { LaunchDesktopFileActionHandler } from "./LaunchDesktopFileActionHandler";
+
+const browserRegistryMock = {
+    getById: () => {
+        return { show: vi.fn(), hide: vi.fn() };
+    },
+} as unknown as BrowserWindowRegistry;
 
 describe(LaunchDesktopFileActionHandler, () => {
     it("should call `gio launch` when executing search result item with the argument file name", async () => {
         const executeCommandMock = vi.fn().mockResolvedValue("");
         const commandlineUtility = <CommandlineUtility>{ executeCommand: (path) => executeCommandMock(path) };
 
-        const actionHandler = new LaunchDesktopFileActionHandler(commandlineUtility);
+        const actionHandler = new LaunchDesktopFileActionHandler(commandlineUtility, browserRegistryMock);
 
         await actionHandler.invokeAction(<SearchResultItemAction>{
             argument: "/usr/share/applications/firefox.desktop",
@@ -25,7 +32,7 @@ describe(LaunchDesktopFileActionHandler, () => {
 
         const commandlineUtility = <CommandlineUtility>{ executeCommand: (path) => executeCommandMock(path) };
 
-        const actionHandler = new LaunchDesktopFileActionHandler(commandlineUtility);
+        const actionHandler = new LaunchDesktopFileActionHandler(commandlineUtility, browserRegistryMock);
 
         await expect(
             actionHandler.invokeAction(<SearchResultItemAction>{ argument: "/usr/share/applications/firefox.desktop" }),

--- a/src/main/Extensions/ApplicationSearch/Linux/LaunchDesktopFileActionHandler.ts
+++ b/src/main/Extensions/ApplicationSearch/Linux/LaunchDesktopFileActionHandler.ts
@@ -1,6 +1,7 @@
 import type { ActionHandler } from "@Core/ActionHandler";
 import type { CommandlineUtility } from "@Core/CommandlineUtility";
 import type { SearchResultItemAction } from "@common/Core";
+import type { BrowserWindowRegistry } from "../../../Core";
 
 /**
  * Action handler for launching a `.desktop` file.
@@ -8,7 +9,10 @@ import type { SearchResultItemAction } from "@common/Core";
 export class LaunchDesktopFileActionHandler implements ActionHandler {
     public readonly id = "LaunchDesktopFile";
 
-    public constructor(private readonly commandlineUtility: CommandlineUtility) {}
+    public constructor(
+        private readonly commandlineUtility: CommandlineUtility,
+        private readonly browserRegistry: BrowserWindowRegistry,
+    ) {}
 
     /**
      * Launches the given `.desktop` file with the desktop environment's respective command.
@@ -16,6 +20,14 @@ export class LaunchDesktopFileActionHandler implements ActionHandler {
      * Throws an error if the file could not be launched or desktop environment isn't supported.
      */
     public async invokeAction(action: SearchResultItemAction): Promise<void> {
-        await this.commandlineUtility.executeCommand(`gio launch ${action.argument}`, { ignoreStdErr: true });
+        const searchWindow = this.browserRegistry.getById("search");
+
+        searchWindow?.hide();
+        try {
+            await this.commandlineUtility.executeCommand(`gio launch ${action.argument}`, { ignoreStdErr: true });
+        } catch (err) {
+            searchWindow?.show();
+            throw err;
+        }
     }
 }


### PR DESCRIPTION
When pressing enter on an item if the app is slow to launch it feels like nothing happened as ueli doesnt show any feedback this pr makes it so that ueli hides itself while launching the app if the app errors it will reappear