### PR TITLE
Alternative to "Improve responsiveness of app launches"

### DIFF
--- a/src/main/Core/ActionHandler/ActionHandlerModule.ts
+++ b/src/main/Core/ActionHandler/ActionHandlerModule.ts
@@ -17,17 +17,7 @@ export class ActionHandlerModule {
                 eventEmitter.emitEvent("actionInvocationStarted", { action });
                 await actionHandlerRegistry.getById(action.handlerId).invokeAction(action);
             } catch (error) {
-                const title = `Error while invoking action`;
-
-                const content = [
-                    `Error: ${error}`,
-                    `HandlerId: ${action.handlerId}`,
-                    `Argument: ${action.argument}`,
-                ].join("\n");
-
-                dialog.showErrorBox(title, content);
-
-                return Promise.reject(`${title}: ${content}`);
+                dialog.showErrorBox("Error while invoking action", `Reason: ${error}`);
             }
         });
     }

--- a/src/main/Core/ActionHandler/ActionHandlerModule.ts
+++ b/src/main/Core/ActionHandler/ActionHandlerModule.ts
@@ -6,7 +6,7 @@ export class ActionHandlerModule {
     public static bootstrap(moduleRegistry: UeliModuleRegistry) {
         const eventEmitter = moduleRegistry.get("EventEmitter");
         const ipcMain = moduleRegistry.get("IpcMain");
-        const logger = moduleRegistry.get("Logger");
+        const dialog = moduleRegistry.get("Dialog");
 
         const actionHandlerRegistry = new ActionHandlerRegistry();
 
@@ -17,9 +17,17 @@ export class ActionHandlerModule {
                 eventEmitter.emitEvent("actionInvocationStarted", { action });
                 await actionHandlerRegistry.getById(action.handlerId).invokeAction(action);
             } catch (error) {
-                const errorMessage = `Error while invoking action: ${error}`;
-                logger.error(errorMessage);
-                return Promise.reject(errorMessage);
+                const title = `Error while invoking action`;
+
+                const content = [
+                    `Error: ${error}`,
+                    `HandlerId: ${action.handlerId}`,
+                    `Argument: ${action.argument}`,
+                ].join("\n");
+
+                dialog.showErrorBox(title, content);
+
+                return Promise.reject(`${title}: ${content}`);
             }
         });
     }

--- a/src/main/Core/ActionHandler/ActionHandlerModule.ts
+++ b/src/main/Core/ActionHandler/ActionHandlerModule.ts
@@ -14,8 +14,8 @@ export class ActionHandlerModule {
 
         ipcMain.handle("invokeAction", async (_, { action }: { action: SearchResultItemAction }) => {
             try {
+                eventEmitter.emitEvent("actionInvocationStarted", { action });
                 await actionHandlerRegistry.getById(action.handlerId).invokeAction(action);
-                eventEmitter.emitEvent("actionInvoked", { action });
             } catch (error) {
                 const errorMessage = `Error while invoking action: ${error}`;
                 logger.error(errorMessage);

--- a/src/main/Core/SearchWindow/SearchWindowModule.ts
+++ b/src/main/Core/SearchWindow/SearchWindowModule.ts
@@ -91,7 +91,7 @@ export class SearchWindowModule {
             }
         });
 
-        eventSubscriber.subscribe("actionInvoked", ({ action }: { action: SearchResultItemAction }) => {
+        eventSubscriber.subscribe("actionInvocationStarted", ({ action }: { action: SearchResultItemAction }) => {
             if (shouldHideWindowAfterInvocation(action)) {
                 browserWindowToggler.hide();
             }


### PR DESCRIPTION
This is an alternative implementation to #1311.

The goal of this PR is to optimistically hide the search window before the action invocation started. This leads to better responsiveness when invoking actions.

Instead of logging an error we can also show an error box. I think that would make more sense as we should make the user aware immidiately that something went wrong. This is an example of the error box on Windows: 
![image](https://github.com/user-attachments/assets/e18336ab-2a42-4508-97ef-a67bdc9a8e65)


