### PR TITLE
Hide window after invocation of workflow extension

### DIFF
--- a/src/main/Extensions/Workflow/WorkflowExtension.ts
+++ b/src/main/Extensions/Workflow/WorkflowExtension.ts
@@ -47,6 +47,7 @@ export class WorkflowExtension implements Extension {
                     description: t("searchResultItemActionDescription"),
                     handlerId: "Workflow",
                     fluentIcon: "OpenRegular",
+                    hideWindowAfterInvocation: true,
                 },
                 description: t("searchResultItemDescription"),
                 id: workflow.id,


### PR DESCRIPTION
Hello :)
I just updated to v9 and migrated my previous Shortcuts to Workflows, but I found out that the window remained open after launching them. Then, I found that a similar commit to fix the same behavior but in the VSCode Extension had recently been pushed.
Greetings!