### PR TITLE
Move search window footer button labels to tooltip

### DIFF
--- a/src/renderer/Core/Footer.tsx
+++ b/src/renderer/Core/Footer.tsx
@@ -11,7 +11,7 @@ export const Footer = ({ children, draggable }: FooterProps) => {
             className={draggable ? "draggable-area" : ""}
             style={{
                 flexShrink: 0,
-                padding: 10,
+                padding: 8,
                 gap: 10,
                 boxSizing: "border-box",
                 display: "flex",

--- a/src/renderer/Core/Search/ActionsMenu/ActionsMenu.tsx
+++ b/src/renderer/Core/Search/ActionsMenu/ActionsMenu.tsx
@@ -11,9 +11,11 @@ import {
     Toast,
     ToastTitle,
     Toaster,
+    Tooltip,
     useId,
     useToastController,
 } from "@fluentui/react-components";
+import { DocumentOnePageRegular } from "@fluentui/react-icons";
 import { useEffect, type Ref } from "react";
 import { useTranslation } from "react-i18next";
 import { FluentIcon } from "../FluentIcon";
@@ -71,20 +73,31 @@ export const ActionsMenu = ({
             <Toaster toasterId={toasterId} />
             <Menu open={open} onOpenChange={(_, { open }) => onOpenChange(open)}>
                 <MenuTrigger>
-                    <Button
-                        disabled={!actions.length}
-                        className="non-draggable-area"
-                        size="small"
-                        appearance="subtle"
-                        ref={additionalActionsButtonRef}
-                    >
-                        {t("actions", { ns: "general" })}
-                        {showKeyboardShortcuts && (
-                            <div style={{ paddingLeft: 5 }}>
-                                <KeyboardShortcut shortcut={keyboardShortcut} />
+                    <Tooltip
+                        content={
+                            <div
+                                style={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    gap: 8,
+                                    marginTop: showKeyboardShortcuts ? 2 : 0,
+                                }}
+                            >
+                                {t("actions", { ns: "general" })}
+                                {showKeyboardShortcuts && <KeyboardShortcut shortcut={keyboardShortcut} />}
                             </div>
-                        )}
-                    </Button>
+                        }
+                        relationship="label"
+                    >
+                        <Button
+                            disabled={!actions.length}
+                            className="non-draggable-area"
+                            size="small"
+                            appearance="subtle"
+                            ref={additionalActionsButtonRef}
+                            icon={<DocumentOnePageRegular fontSize={18} />}
+                        />
+                    </Tooltip>
                 </MenuTrigger>
                 <MenuPopover>
                     <MenuList>

--- a/src/renderer/Core/Search/Search.tsx
+++ b/src/renderer/Core/Search/Search.tsx
@@ -1,8 +1,8 @@
 import { KeyboardShortcut } from "@Core/Components";
 import { useSetting } from "@Core/Hooks";
 import type { SearchResultItem } from "@common/Core";
-import { Button, Text, tokens } from "@fluentui/react-components";
-import { SettingsRegular } from "@fluentui/react-icons";
+import { Button, Text, tokens, Tooltip } from "@fluentui/react-components";
+import { PlayCircleRegular, SettingsRegular } from "@fluentui/react-icons";
 import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { BaseLayout } from "../BaseLayout";
@@ -313,37 +313,61 @@ export const Search = ({
             }
             footer={
                 <Footer draggable>
-                    <Button
-                        className="non-draggable-area"
-                        onClick={openSettings}
-                        size="small"
-                        appearance="subtle"
-                        icon={<SettingsRegular fontSize={14} />}
-                    >
-                        {t("settings", { ns: "general" })}
-                        {showKeyboardShortcuts && (
-                            <div style={{ paddingLeft: 5 }}>
-                                <KeyboardShortcut
-                                    shortcut={window.ContextBridge.getOperatingSystem() === "macOS" ? "⌘+," : "^+,"}
-                                />
-                            </div>
-                        )}
-                    </Button>
-                    <div>
-                        {searchResult.current() ? (
-                            <Button
-                                className="non-draggable-area"
-                                size="small"
-                                appearance="subtle"
-                                onClick={invokeSelectedSearchResultItem}
+                    <Tooltip
+                        content={
+                            <div
+                                style={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    gap: 8,
+                                    marginTop: showKeyboardShortcuts ? 2 : 0,
+                                }}
                             >
-                                {searchResult.current()?.defaultAction.description}
+                                {t("settings", { ns: "general" })}
                                 {showKeyboardShortcuts && (
-                                    <div style={{ paddingLeft: 5 }}>
-                                        <KeyboardShortcut shortcut="↵" />
-                                    </div>
+                                    <KeyboardShortcut
+                                        shortcut={window.ContextBridge.getOperatingSystem() === "macOS" ? "⌘+," : "^+,"}
+                                    />
                                 )}
-                            </Button>
+                            </div>
+                        }
+                        relationship="label"
+                    >
+                        <Button
+                            className="non-draggable-area"
+                            onClick={openSettings}
+                            size="small"
+                            appearance="subtle"
+                            icon={<SettingsRegular fontSize={18} />}
+                        />
+                    </Tooltip>
+
+                    <div style={{ display: "flex", gap: 4 }}>
+                        {searchResult.current() ? (
+                            <Tooltip
+                                content={
+                                    <div
+                                        style={{
+                                            display: "flex",
+                                            alignItems: "center",
+                                            gap: 8,
+                                            marginTop: showKeyboardShortcuts ? 2 : 0,
+                                        }}
+                                    >
+                                        {searchResult.current()?.defaultAction.description}
+                                        {showKeyboardShortcuts && <KeyboardShortcut shortcut="↵" />}
+                                    </div>
+                                }
+                                relationship="label"
+                            >
+                                <Button
+                                    className="non-draggable-area"
+                                    size="small"
+                                    appearance="subtle"
+                                    onClick={invokeSelectedSearchResultItem}
+                                    icon={<PlayCircleRegular fontSize={18} />}
+                                />
+                            </Tooltip>
                         ) : null}
                         <ActionsMenu
                             searchResultItem={searchResult.current()}


### PR DESCRIPTION
As suggested in #1308, this PR moves the labels and keyboard shortcuts of the search window footer buttons to tooltips.

![grafik](https://github.com/user-attachments/assets/def33824-d47b-434d-9eaf-c5ad2ac52060)