### PR TITLE
fix: map AltGr to Ctrl+Alt for Windows

### DIFF
--- a/src/main/Core/GlobalShortcut/GlobalShortcutModule.ts
+++ b/src/main/Core/GlobalShortcut/GlobalShortcutModule.ts
@@ -12,7 +12,13 @@ export class GlobalShortcutModule {
         const hotkeyIsEnabled = () => settingsManager.getValue("general.hotkey.enabled", true);
 
         const registerHotkey = () => {
-            const hotkey = settingsManager.getValue("general.hotkey", "Alt+Space");
+            let hotkey = settingsManager.getValue("general.hotkey", "Alt+Space");
+            const operatingSystem = moduleRegistry.get("OperatingSystem");
+
+            // Replace AltGr with Ctrl+Alt on Windows due to OS mapping
+            if(operatingSystem === "Windows") {
+                hotkey = hotkey.replace('AltGr', 'Ctrl+Alt');
+            }              
 
             if (!isValidHotkey(hotkey)) {
                 logger.error(`Unable to register hotkey. Reason: unexpected hotkey ${hotkey}`);


### PR DESCRIPTION
Windows maps AltGr to Ctrl+Alt why AltGr does not work. This fix replaces AltGr with Ctrl+Alt before regestering the hot key. 

Fixes #589