### PR TITLE
Add hotkey for show in file eplorer

### DIFF
--- a/src/renderer/Core/Search/Search.tsx
+++ b/src/renderer/Core/Search/Search.tsx
@@ -86,6 +86,17 @@ export const Search = ({
                 },
                 needsToInvokeListener: (keyboardEvent) => keyboardEvent.key === "Enter",
             },
+            {
+                listener: () => {
+                    const action = searchResultItems
+                        .find((i) => i.id === selectedItemId.value)
+                        ?.additionalActions?.find((a) => a.handlerId === "ShowItemInFileExplorer");
+                    if (action) {
+                        invokeAction(action);
+                    }
+                },
+                needsToInvokeListener: (keyboardEvent) => keyboardEvent.ctrlKey && keyboardEvent.key === "o",
+            },
         ];
 
         for (const eventHandler of eventHandlers) {


### PR DESCRIPTION
This adds the hotkey <kbd>CTRL</kbd>+<kbd>O</kbd> like in ueli 8 for show in file explorer. I use this a lot and the action menu is just too cumbersome for this.