### PR TITLE
Fix Windows store app autostart

### DIFF
--- a/src/main/Core/Autostart/AutostartModule.ts
+++ b/src/main/Core/Autostart/AutostartModule.ts
@@ -11,7 +11,7 @@ export class AutostartModule {
         const fileSystemUtility = moduleRegistry.get("FileSystemUtility");
 
         const autostartManager = process.windowsStore
-            ? new WindowsStoreAutostartManager(app, shell, process, fileSystemUtility, logger)
+            ? new WindowsStoreAutostartManager(app, shell, fileSystemUtility, logger)
             : new DefaultAutostartManager(app, process);
 
         const setAutostartOptions = (openAtLogin: boolean) => {

--- a/src/main/Core/Autostart/WindowsStoreAutostartManager.ts
+++ b/src/main/Core/Autostart/WindowsStoreAutostartManager.ts
@@ -5,10 +5,12 @@ import { join } from "path";
 import type { AutostartManager } from "./AutostartManager";
 
 export class WindowsStoreAutostartManager implements AutostartManager {
+    private readonly appId = "1915OliverSchwendener.Ueli_a397x08q5x7rp!OliverSchwendener.Ueli";
+    private readonly shortcutTarget = `shell:AppsFolder\\${this.appId}`;
+
     public constructor(
         private readonly app: App,
         private readonly shell: Shell,
-        private readonly process: NodeJS.Process,
         private readonly fileSystemUtility: FileSystemUtility,
         private readonly logger: Logger,
     ) {}
@@ -32,7 +34,12 @@ export class WindowsStoreAutostartManager implements AutostartManager {
 
         try {
             const shortcutLink = this.shell.readShortcutLink(shortcutFilePath);
-            return shortcutLink.target === this.process.execPath;
+            if (shortcutLink.target) {
+                return shortcutLink.target === this.shortcutTarget;
+            }
+
+            const shortcutFileContent = this.fileSystemUtility.readTextFileSync(shortcutFilePath, "utf-16le");
+            return shortcutFileContent.includes(this.appId);
         } catch (error) {
             this.logger.error(`Failed to read shortcut link "${shortcutFilePath}". Reason: ${error}`);
             return false;
@@ -55,7 +62,7 @@ export class WindowsStoreAutostartManager implements AutostartManager {
         const shortcutFileExists = this.fileSystemUtility.existsSync(shortcutFilePath);
 
         this.shell.writeShortcutLink(shortcutFilePath, shortcutFileExists ? "replace" : "create", {
-            target: this.process.execPath,
+            target: this.shortcutTarget,
         });
     }
 

--- a/src/main/Core/Autostart/WindowsStoreAutostartManager.ts
+++ b/src/main/Core/Autostart/WindowsStoreAutostartManager.ts
@@ -33,11 +33,6 @@ export class WindowsStoreAutostartManager implements AutostartManager {
         }
 
         try {
-            const shortcutLink = this.shell.readShortcutLink(shortcutFilePath);
-            if (shortcutLink.target) {
-                return shortcutLink.target === this.shortcutTarget;
-            }
-
             const shortcutFileContent = this.fileSystemUtility.readTextFileSync(shortcutFilePath, "utf-16le");
             return shortcutFileContent.includes(this.appId);
         } catch (error) {

--- a/src/main/Core/FileSystemUtility/Contract/FileSystemUtility.ts
+++ b/src/main/Core/FileSystemUtility/Contract/FileSystemUtility.ts
@@ -4,8 +4,8 @@ export interface FileSystemUtility {
     pathExists(fileOrFolderPath: string): Promise<boolean>;
     readFileSync(filePath: string): Buffer;
     readFile(filePath: string): Promise<Buffer>;
-    readTextFileSync(filePath: string): string;
-    readTextFile(filePath: string): Promise<string>;
+    readTextFileSync(filePath: string, encoding?: BufferEncoding): string;
+    readTextFile(filePath: string, encoding?: BufferEncoding): Promise<string>;
     readJsonFile<T>(filePath: string): Promise<T>;
     readJsonFileSync<T>(filePath: string): T;
     readDirectory(folderPath: string, recursive?: boolean): Promise<string[]>;

--- a/src/main/Core/FileSystemUtility/NodeJsFileSystemUtility.test.ts
+++ b/src/main/Core/FileSystemUtility/NodeJsFileSystemUtility.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, rm } from "fs/promises";
+import { mkdir, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { NodeJsFileSystemUtility } from "./NodeJsFileSystemUtility";
@@ -233,6 +233,18 @@ describe(NodeJsFileSystemUtility, () => {
 
             expect(actual).toBe(content);
         });
+
+        it("should read the contents of a utf-16le encoded file as a string", async () => {
+            const fileSystemUtility = new NodeJsFileSystemUtility();
+            const filePath = join(tempFolderPath, "file.txt");
+            const content = "test";
+
+            await writeFile(filePath, content, { encoding: "utf-16le" });
+
+            const actual = await fileSystemUtility.readTextFile(filePath, "utf-16le");
+
+            expect(actual).toBe(content);
+        });
     });
 
     describe(NodeJsFileSystemUtility.prototype.readTextFileSync, () => {
@@ -244,6 +256,16 @@ describe(NodeJsFileSystemUtility, () => {
             await fileSystemUtility.writeTextFile(content, filePath);
 
             expect(fileSystemUtility.readTextFileSync(filePath)).toBe(content);
+        });
+
+        it("should read the contents of a utf-16le encoded file synchronously as a string", async () => {
+            const fileSystemUtility = new NodeJsFileSystemUtility();
+            const filePath = join(tempFolderPath, "file.txt");
+            const content = "test";
+
+            await writeFile(filePath, content, { encoding: "utf-16le" });
+
+            expect(fileSystemUtility.readTextFileSync(filePath, "utf-16le")).toBe(content);
         });
     });
 

--- a/src/main/Core/FileSystemUtility/NodeJsFileSystemUtility.ts
+++ b/src/main/Core/FileSystemUtility/NodeJsFileSystemUtility.ts
@@ -88,12 +88,12 @@ export class NodeJsFileSystemUtility implements FileSystemUtility {
         return readFileSync(filePath);
     }
 
-    public readTextFileSync(filePath: string): string {
-        return this.readFileSync(filePath).toString();
+    public readTextFileSync(filePath: string, encoding?: BufferEncoding): string {
+        return this.readFileSync(filePath).toString(encoding);
     }
 
-    public async readTextFile(filePath: string): Promise<string> {
-        return (await this.readFile(filePath)).toString();
+    public async readTextFile(filePath: string, encoding?: BufferEncoding): Promise<string> {
+        return (await this.readFile(filePath)).toString(encoding);
     }
 
     public async readDirectory(folderPath: string, recursive?: boolean): Promise<string[]> {


### PR DESCRIPTION
This fixes #1137 by creating a shortcut link with target `shell:AppsFolder\\1915OliverSchwendener.Ueli_a397x08q5x7rp!OliverSchwendener.Ueli`.

I had to use a quite ugly workaround to check if the file contains the correct target since Electron's `readShortcutLink` method does return an empty target for Windows store app lnk files.