### PR TITLE
VSCode Extension fix macos default command

### DIFF
--- a/src/main/Extensions/VSCode/VSCodeExtension.ts
+++ b/src/main/Extensions/VSCode/VSCodeExtension.ts
@@ -185,8 +185,18 @@ export class VSCodeExtension implements Extension {
     public getSettingDefaultValue(key: keyof Settings) {
         const defaultSettings: Settings = {
             prefix: "vscode",
-            command: 'code "%s"',
+            command: "",
         };
+
+        switch (this.operatingSystem) {
+            case "Windows":
+            case "Linux":
+                defaultSettings.command = "code %s";
+                break;
+            case "macOS":
+                defaultSettings.command = "/usr/local/bin/code %s";
+                break;
+        }
 
         return defaultSettings[key];
     }

--- a/src/main/Extensions/VSCode/VSCodeExtension.ts
+++ b/src/main/Extensions/VSCode/VSCodeExtension.ts
@@ -185,17 +185,11 @@ export class VSCodeExtension implements Extension {
     public getSettingDefaultValue(key: keyof Settings) {
         const defaultSettings: Settings = {
             prefix: "vscode",
-            command: "",
+            command: "code %s",
         };
 
-        switch (this.operatingSystem) {
-            case "Windows":
-            case "Linux":
-                defaultSettings.command = "code %s";
-                break;
-            case "macOS":
-                defaultSettings.command = "/usr/local/bin/code %s";
-                break;
+        if (this.operatingSystem === "macOS") {
+            defaultSettings.command = "/usr/local/bin/code %s";
         }
 
         return defaultSettings[key];


### PR DESCRIPTION
fixes #1334

VSCode Extension fix macos default command by setting it to the common install location of `/usr/local/bin/code %s`