### PR TITLE
Fixed bug with wrong results and low precision

### DIFF
--- a/src/main/Extensions/Calculator/Calculator.test.ts
+++ b/src/main/Extensions/Calculator/Calculator.test.ts
@@ -248,5 +248,16 @@ describe(Calculator, () => {
                 }),
             ).toEqual("5035");
         });
+
+        it("should return 5035 when evaluating the expression '5050-15' and a precision of 1", () => {
+            expect(
+                Calculator.calculate({
+                    expression: "5050-15",
+                    argumentSeparator: ",",
+                    decimalSeparator: ".",
+                    precision: 1,
+                }),
+            ).toEqual("5035");
+        });
     });
 });

--- a/src/main/Extensions/Calculator/Calculator.ts
+++ b/src/main/Extensions/Calculator/Calculator.ts
@@ -72,15 +72,14 @@ export class Calculator {
             precision = 16;
         }
 
-        const math = create(all, { precision, number: "BigNumber" });
+        const math = create(all, { precision: 64, number: "BigNumber" });
 
-        const result = String(
+        const calculationResult = String(
             math.evaluate(this.normalizeExpression({ expression, decimalSeparator, argumentSeparator })),
-        );
+        ).replace(/[,.]/g, (match) => (match === "." ? decimalSeparator : argumentSeparator));
 
-        return result.replace(new RegExp(",|\\.", "g"), (match) =>
-            match === "." ? decimalSeparator : argumentSeparator,
-        );
+        const result = Number(calculationResult);
+        return isNaN(result) ? calculationResult : result.toFixed(precision).replace(/(\.0*|(?<=(\..*))0*)$/, "");
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This could be a potential fix for bug #1171
Always calculate with high precision and format the result to the desired precision if it's numeric.