### PR TITLE
feat: introduce search result list layout options

### DIFF
--- a/src/renderer/Core/Components/BasicSearch.tsx
+++ b/src/renderer/Core/Components/BasicSearch.tsx
@@ -15,6 +15,7 @@ type BasicSearchProps = {
     inputPlaceholder?: string;
     debounceDurationInMs?: number;
     showGoBackButton?: boolean;
+    layout?: "compact" | "detailed";
 };
 
 export const BasicSearch = ({
@@ -22,6 +23,7 @@ export const BasicSearch = ({
     inputPlaceholder,
     debounceDurationInMs,
     showGoBackButton,
+    layout,
 }: BasicSearchProps) => {
     const navigate = useNavigate();
     const [searchTerm, setSearchTerm] = useState<string>("");
@@ -166,6 +168,7 @@ export const BasicSearch = ({
                             searchResultItems={searchResultItems}
                             selectedItemId={selectedItemId}
                             searchTerm={searchTerm}
+                            layout={layout ?? "compact"}
                         />
                     </div>
                 )

--- a/src/renderer/Core/Components/BasicSearch.tsx
+++ b/src/renderer/Core/Components/BasicSearch.tsx
@@ -3,6 +3,7 @@ import { Header } from "@Core/Header";
 import { getNextSearchResultItemId } from "@Core/Search/Helpers/getNextSearchResultItemId";
 import { getPreviousSearchResultItemId } from "@Core/Search/Helpers/getPreviousSearchResultItemId";
 import { SearchResultList } from "@Core/Search/SearchResultList";
+import type { SearchResultListLayout } from "@Core/Search/SearchResultListLayout";
 import type { SearchResultItem } from "@common/Core";
 import { Button, Input, ProgressBar } from "@fluentui/react-components";
 import { ArrowLeftFilled, SearchRegular } from "@fluentui/react-icons";
@@ -15,7 +16,7 @@ type BasicSearchProps = {
     inputPlaceholder?: string;
     debounceDurationInMs?: number;
     showGoBackButton?: boolean;
-    layout?: "compact" | "detailed";
+    searchResultListLayout?: SearchResultListLayout;
 };
 
 export const BasicSearch = ({
@@ -23,7 +24,7 @@ export const BasicSearch = ({
     inputPlaceholder,
     debounceDurationInMs,
     showGoBackButton,
-    layout,
+    searchResultListLayout,
 }: BasicSearchProps) => {
     const navigate = useNavigate();
     const [searchTerm, setSearchTerm] = useState<string>("");
@@ -168,7 +169,7 @@ export const BasicSearch = ({
                             searchResultItems={searchResultItems}
                             selectedItemId={selectedItemId}
                             searchTerm={searchTerm}
-                            layout={layout ?? "compact"}
+                            layout={searchResultListLayout ?? "compact"}
                         />
                     </div>
                 )

--- a/src/renderer/Core/Search/CompactSearchResultListItem.tsx
+++ b/src/renderer/Core/Search/CompactSearchResultListItem.tsx
@@ -1,0 +1,64 @@
+import type { SearchResultItem } from "@common/Core";
+import { Text, tokens } from "@fluentui/react-components";
+import { useTranslation } from "react-i18next";
+import { SearchResultItemImage } from "./SearchResultItemImage";
+
+type CompactSearchResultListItemProps = {
+    isSelected: boolean;
+    searchResultItem: SearchResultItem;
+};
+
+export const CompactSearchResultListItem = ({ isSelected, searchResultItem }: CompactSearchResultListItemProps) => {
+    const { t } = useTranslation();
+
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "flex-start",
+                height: 36,
+                padding: 10,
+                boxSizing: "border-box",
+                gap: 10,
+                width: "100%",
+            }}
+        >
+            <div
+                style={{
+                    position: "absolute",
+                    left: 0,
+                    top: "50%",
+                    backgroundColor: isSelected ? tokens.colorBrandForeground1 : "transparent",
+                    height: "45%",
+                    width: 3,
+                    transform: "translateY(-50%)",
+                    borderRadius: tokens.borderRadiusLarge,
+                }}
+            ></div>
+            <SearchResultItemImage image={searchResultItem.image} altText={searchResultItem.name} size={20} />
+            <Text
+                size={300}
+                style={{
+                    width: "100%",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 5,
+                }}
+            >
+                {searchResultItem.name}
+            </Text>
+            <Text size={200} style={{ flexShrink: 0 }}>
+                {searchResultItem.descriptionTranslation
+                    ? t(searchResultItem.descriptionTranslation.key, {
+                          ns: searchResultItem.descriptionTranslation.namespace,
+                      })
+                    : searchResultItem.description}
+            </Text>
+        </div>
+    );
+};

--- a/src/renderer/Core/Search/CompactSearchResultListItem.tsx
+++ b/src/renderer/Core/Search/CompactSearchResultListItem.tsx
@@ -19,11 +19,12 @@ export const CompactSearchResultListItem = ({ searchResultItem }: CompactSearchR
                 justifyContent: "space-between",
                 padding: 8,
                 boxSizing: "border-box",
-                gap: 10,
+                gap: 8,
                 width: "100%",
             }}
         >
-            <div style={{ flexShrink: 0 }}>
+            {/* The left margin makes sure that the icon has the correct space horizontally */}
+            <div style={{ flexShrink: 0, marginLeft: 2 }}>
                 <SearchResultItemImage image={searchResultItem.image} altText={searchResultItem.name} size={20} />
             </div>
             <Text

--- a/src/renderer/Core/Search/CompactSearchResultListItem.tsx
+++ b/src/renderer/Core/Search/CompactSearchResultListItem.tsx
@@ -1,14 +1,13 @@
 import type { SearchResultItem } from "@common/Core";
-import { Text, tokens } from "@fluentui/react-components";
+import { Text } from "@fluentui/react-components";
 import { useTranslation } from "react-i18next";
 import { SearchResultItemImage } from "./SearchResultItemImage";
 
 type CompactSearchResultListItemProps = {
-    isSelected: boolean;
     searchResultItem: SearchResultItem;
 };
 
-export const CompactSearchResultListItem = ({ isSelected, searchResultItem }: CompactSearchResultListItemProps) => {
+export const CompactSearchResultListItem = ({ searchResultItem }: CompactSearchResultListItemProps) => {
     const { t } = useTranslation();
 
     return (
@@ -25,18 +24,6 @@ export const CompactSearchResultListItem = ({ isSelected, searchResultItem }: Co
                 width: "100%",
             }}
         >
-            <div
-                style={{
-                    position: "absolute",
-                    left: 0,
-                    top: "50%",
-                    backgroundColor: isSelected ? tokens.colorBrandForeground1 : "transparent",
-                    height: "45%",
-                    width: 3,
-                    transform: "translateY(-50%)",
-                    borderRadius: tokens.borderRadiusLarge,
-                }}
-            ></div>
             <SearchResultItemImage image={searchResultItem.image} altText={searchResultItem.name} size={20} />
             <Text
                 size={300}

--- a/src/renderer/Core/Search/CompactSearchResultListItem.tsx
+++ b/src/renderer/Core/Search/CompactSearchResultListItem.tsx
@@ -1,5 +1,5 @@
 import type { SearchResultItem } from "@common/Core";
-import { Text } from "@fluentui/react-components";
+import { Badge, Text } from "@fluentui/react-components";
 import { useTranslation } from "react-i18next";
 import { SearchResultItemImage } from "./SearchResultItemImage";
 
@@ -16,36 +16,35 @@ export const CompactSearchResultListItem = ({ searchResultItem }: CompactSearchR
                 display: "flex",
                 flexDirection: "row",
                 alignItems: "center",
-                justifyContent: "flex-start",
-                height: 36,
-                padding: 10,
+                justifyContent: "space-between",
+                padding: 8,
                 boxSizing: "border-box",
                 gap: 10,
                 width: "100%",
             }}
         >
-            <SearchResultItemImage image={searchResultItem.image} altText={searchResultItem.name} size={20} />
+            <div style={{ flexShrink: 0 }}>
+                <SearchResultItemImage image={searchResultItem.image} altText={searchResultItem.name} size={20} />
+            </div>
             <Text
-                size={300}
                 style={{
-                    width: "100%",
+                    flexGrow: 1,
+                    whiteSpace: "nowrap",
                     overflow: "hidden",
                     textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 5,
                 }}
             >
                 {searchResultItem.name}
             </Text>
-            <Text size={200} style={{ flexShrink: 0 }}>
-                {searchResultItem.descriptionTranslation
-                    ? t(searchResultItem.descriptionTranslation.key, {
-                          ns: searchResultItem.descriptionTranslation.namespace,
-                      })
-                    : searchResultItem.description}
-            </Text>
+            <div style={{ flexShrink: 0, display: "flex" }}>
+                <Badge color="subtle" size="small">
+                    {searchResultItem.descriptionTranslation
+                        ? t(searchResultItem.descriptionTranslation.key, {
+                              ns: searchResultItem.descriptionTranslation.namespace,
+                          })
+                        : searchResultItem.description}
+                </Badge>
+            </div>
         </div>
     );
 };

--- a/src/renderer/Core/Search/DetailedSearchResultItem.tsx
+++ b/src/renderer/Core/Search/DetailedSearchResultItem.tsx
@@ -17,14 +17,14 @@ export const DetailedSearchResultListItem = ({ searchResultItem }: DetailedSearc
                 flexDirection: "row",
                 alignItems: "center",
                 justifyContent: "space-between",
-                padding: 8,
+                padding: "8px 10px",
                 boxSizing: "border-box",
                 gap: 10,
                 width: "100%",
             }}
         >
             {/* The left margin makes sure that the icon has the correct space horizontally */}
-            <div style={{ flexShrink: 0, marginLeft: 4 }}>
+            <div style={{ flexShrink: 0, marginLeft: 2 }}>
                 <SearchResultItemImage image={searchResultItem.image} altText={searchResultItem.name} size={24} />
             </div>
             <div style={{ display: "flex", flexDirection: "column", flexGrow: 1, overflow: "hidden" }}>

--- a/src/renderer/Core/Search/DetailedSearchResultItem.tsx
+++ b/src/renderer/Core/Search/DetailedSearchResultItem.tsx
@@ -1,0 +1,62 @@
+import type { SearchResultItem } from "@common/Core";
+import { Badge, Text } from "@fluentui/react-components";
+import { useTranslation } from "react-i18next";
+import { SearchResultItemImage } from "./SearchResultItemImage";
+
+type DetailedSearchResultListItemProps = {
+    searchResultItem: SearchResultItem;
+};
+
+export const DetailedSearchResultListItem = ({ searchResultItem }: DetailedSearchResultListItemProps) => {
+    const { t } = useTranslation();
+
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "space-between",
+                padding: 8,
+                boxSizing: "border-box",
+                gap: 10,
+                width: "100%",
+            }}
+        >
+            <div style={{ flexShrink: 0 }}>
+                <SearchResultItemImage image={searchResultItem.image} altText={searchResultItem.name} size={24} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", flexGrow: 1, overflow: "hidden" }}>
+                <Text
+                    weight="semibold"
+                    style={{
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                    }}
+                >
+                    {searchResultItem.name}
+                </Text>
+                <Text
+                    size={200}
+                    style={{
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                    }}
+                >
+                    PLACEHOLDER DETAILS
+                </Text>
+            </div>
+            <div style={{ flexShrink: 0, display: "flex" }}>
+                <Badge color="subtle" size="small">
+                    {searchResultItem.descriptionTranslation
+                        ? t(searchResultItem.descriptionTranslation.key, {
+                              ns: searchResultItem.descriptionTranslation.namespace,
+                          })
+                        : searchResultItem.description}
+                </Badge>
+            </div>
+        </div>
+    );
+};

--- a/src/renderer/Core/Search/DetailedSearchResultItem.tsx
+++ b/src/renderer/Core/Search/DetailedSearchResultItem.tsx
@@ -46,7 +46,7 @@ export const DetailedSearchResultListItem = ({ searchResultItem }: DetailedSearc
                         textOverflow: "ellipsis",
                     }}
                 >
-                    PLACEHOLDER DETAILS
+                    Here go the details of the search resul item
                 </Text>
             </div>
             <div style={{ flexShrink: 0, display: "flex" }}>

--- a/src/renderer/Core/Search/DetailedSearchResultItem.tsx
+++ b/src/renderer/Core/Search/DetailedSearchResultItem.tsx
@@ -23,7 +23,8 @@ export const DetailedSearchResultListItem = ({ searchResultItem }: DetailedSearc
                 width: "100%",
             }}
         >
-            <div style={{ flexShrink: 0 }}>
+            {/* The left margin makes sure that the icon has the correct space horizontally */}
+            <div style={{ flexShrink: 0, marginLeft: 4 }}>
                 <SearchResultItemImage image={searchResultItem.image} altText={searchResultItem.name} size={24} />
             </div>
             <div style={{ display: "flex", flexDirection: "column", flexGrow: 1, overflow: "hidden" }}>

--- a/src/renderer/Core/Search/Search.tsx
+++ b/src/renderer/Core/Search/Search.tsx
@@ -354,7 +354,7 @@ export const Search = ({
                                         searchTerm={searchTerm.value}
                                         onSearchResultItemClick={handleSearchResultItemClickEvent}
                                         onSearchResultItemDoubleClick={handleSearchResultItemDoubleClickEvent}
-                                        layout="compact"
+                                        layout="detailed"
                                     />
                                 </div>
                             ))}

--- a/src/renderer/Core/Search/Search.tsx
+++ b/src/renderer/Core/Search/Search.tsx
@@ -354,7 +354,7 @@ export const Search = ({
                                         searchTerm={searchTerm.value}
                                         onSearchResultItemClick={handleSearchResultItemClickEvent}
                                         onSearchResultItemDoubleClick={handleSearchResultItemDoubleClickEvent}
-                                        layout="detailed"
+                                        layout="compact"
                                     />
                                 </div>
                             ))}

--- a/src/renderer/Core/Search/Search.tsx
+++ b/src/renderer/Core/Search/Search.tsx
@@ -354,6 +354,7 @@ export const Search = ({
                                         searchTerm={searchTerm.value}
                                         onSearchResultItemClick={handleSearchResultItemClickEvent}
                                         onSearchResultItemDoubleClick={handleSearchResultItemDoubleClickEvent}
+                                        layout="compact"
                                     />
                                 </div>
                             ))}

--- a/src/renderer/Core/Search/SearchResultItemImage.tsx
+++ b/src/renderer/Core/Search/SearchResultItemImage.tsx
@@ -1,0 +1,38 @@
+import type { SearchResultItem } from "@common/Core";
+import { getImageUrl } from "@Core/getImageUrl";
+import { ThemeContext } from "@Core/Theme";
+import { useContext } from "react";
+
+type SearchResultItemImageProps = {
+    image: SearchResultItem["image"];
+    altText: string;
+    size: number;
+};
+
+export const SearchResultItemImage = ({ image, altText, size }: SearchResultItemImageProps) => {
+    const { shouldUseDarkColors } = useContext(ThemeContext);
+
+    return (
+        <div
+            style={{
+                alignItems: "center",
+                display: "flex",
+                flexDirection: "row",
+                flexShrink: 0,
+                justifyContent: "center",
+                width: size,
+                height: size,
+            }}
+        >
+            <img
+                alt={altText}
+                loading="lazy"
+                style={{
+                    maxHeight: "100%",
+                    maxWidth: "100%",
+                }}
+                src={getImageUrl({ image, shouldUseDarkColors })}
+            />
+        </div>
+    );
+};

--- a/src/renderer/Core/Search/SearchResultList.tsx
+++ b/src/renderer/Core/Search/SearchResultList.tsx
@@ -4,6 +4,7 @@ import type { RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useSetting } from "../Hooks";
 import { SearchResultListItem } from "./SearchResultListItem";
+import type { SearchResultListLayout } from "./SearchResultListLayout";
 
 type SearchResultListProps = {
     containerRef: RefObject<HTMLDivElement>;
@@ -12,7 +13,7 @@ type SearchResultListProps = {
     searchTerm?: string;
     onSearchResultItemClick: (searchResultItem: SearchResultItem) => void;
     onSearchResultItemDoubleClick: (searchResultItem: SearchResultItem) => void;
-    layout: "compact" | "detailed";
+    layout: SearchResultListLayout;
 };
 
 export const SearchResultList = ({

--- a/src/renderer/Core/Search/SearchResultList.tsx
+++ b/src/renderer/Core/Search/SearchResultList.tsx
@@ -12,6 +12,7 @@ type SearchResultListProps = {
     searchTerm?: string;
     onSearchResultItemClick: (searchResultItem: SearchResultItem) => void;
     onSearchResultItemDoubleClick: (searchResultItem: SearchResultItem) => void;
+    layout: "compact" | "detailed";
 };
 
 export const SearchResultList = ({
@@ -21,6 +22,7 @@ export const SearchResultList = ({
     searchTerm,
     onSearchResultItemClick,
     onSearchResultItemDoubleClick,
+    layout,
 }: SearchResultListProps) => {
     const { t } = useTranslation();
 
@@ -55,6 +57,7 @@ export const SearchResultList = ({
                     onClick={() => onSearchResultItemClick(searchResultItem)}
                     onDoubleClick={() => onSearchResultItemDoubleClick(searchResultItem)}
                     scrollBehavior={scrollBehavior}
+                    layout={layout}
                 />
             ))}
         </div>

--- a/src/renderer/Core/Search/SearchResultListItem.tsx
+++ b/src/renderer/Core/Search/SearchResultListItem.tsx
@@ -1,9 +1,7 @@
-import { ThemeContext } from "@Core/Theme";
-import { getImageUrl } from "@Core/getImageUrl";
 import type { SearchResultItem } from "@common/Core";
-import { Text, tokens } from "@fluentui/react-components";
-import { useContext, useEffect, useRef, useState, type RefObject } from "react";
-import { useTranslation } from "react-i18next";
+import { tokens } from "@fluentui/react-components";
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { CompactSearchResultListItem } from "./CompactSearchResultListItem";
 import { elementIsVisible } from "./Helpers";
 
 type SearchResultListItemProps = {
@@ -23,9 +21,6 @@ export const SearchResultListItem = ({
     searchResultItem,
     scrollBehavior,
 }: SearchResultListItemProps) => {
-    const { shouldUseDarkColors } = useContext(ThemeContext);
-    const { t } = useTranslation();
-
     const ref = useRef<HTMLDivElement>(null);
     const [isHovered, setIsHovered] = useState<boolean>(false);
 
@@ -38,7 +33,9 @@ export const SearchResultListItem = ({
     const selectedBackgroundColor = tokens.colorNeutralBackground1Selected;
     const hoveredBackgroundColor = tokens.colorNeutralBackground1Hover;
 
-    useEffect(scrollIntoViewIfSelectedAndNotVisible, [isSelected]);
+    useEffect(() => {
+        scrollIntoViewIfSelectedAndNotVisible();
+    }, [isSelected]);
 
     return (
         <div
@@ -51,75 +48,13 @@ export const SearchResultListItem = ({
             style={{
                 position: "relative",
                 backgroundColor: isSelected ? selectedBackgroundColor : isHovered ? hoveredBackgroundColor : undefined,
-                boxSizing: "border-box",
                 color: isSelected ? tokens.colorNeutralForeground1Selected : undefined,
-                display: "flex",
-                flexDirection: "row",
-                alignItems: "center",
-                justifyContent: "flex-start",
-                gap: 10,
-                height: 36,
-                width: "100%",
-                padding: 10,
                 userSelect: "none",
                 borderRadius: tokens.borderRadiusMedium,
                 cursor: "pointer",
             }}
         >
-            <div
-                style={{
-                    position: "absolute",
-                    left: 0,
-                    top: "50%",
-                    backgroundColor: isSelected ? tokens.colorBrandForeground1 : "transparent",
-                    height: "45%",
-                    width: 3,
-                    transform: "translateY(-50%)",
-                    borderRadius: tokens.borderRadiusLarge,
-                }}
-            ></div>
-            <div
-                style={{
-                    alignItems: "center",
-                    display: "flex",
-                    flexDirection: "row",
-                    flexShrink: 0,
-                    justifyContent: "center",
-                    width: 20,
-                    height: 20,
-                }}
-            >
-                <img
-                    alt={searchResultItem.name}
-                    loading="lazy"
-                    style={{
-                        maxHeight: "100%",
-                        maxWidth: "100%",
-                    }}
-                    src={getImageUrl({ image: searchResultItem.image, shouldUseDarkColors })}
-                />
-            </div>
-            <Text
-                size={300}
-                style={{
-                    width: "100%",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 5,
-                }}
-            >
-                {searchResultItem.name}
-            </Text>
-            <Text size={200} style={{ flexShrink: 0 }}>
-                {searchResultItem.descriptionTranslation
-                    ? t(searchResultItem.descriptionTranslation.key, {
-                          ns: searchResultItem.descriptionTranslation.namespace,
-                      })
-                    : searchResultItem.description}
-            </Text>
+            <CompactSearchResultListItem isSelected={isSelected} searchResultItem={searchResultItem} />
         </div>
     );
 };

--- a/src/renderer/Core/Search/SearchResultListItem.tsx
+++ b/src/renderer/Core/Search/SearchResultListItem.tsx
@@ -3,6 +3,7 @@ import { tokens } from "@fluentui/react-components";
 import { useEffect, useRef, useState, type RefObject } from "react";
 import { CompactSearchResultListItem } from "./CompactSearchResultListItem";
 import { elementIsVisible } from "./Helpers";
+import { SearchResultListItemSelectedIndicator } from "./SearchResultListItemSelectedIndicator";
 
 type SearchResultListItemProps = {
     containerRef: RefObject<HTMLDivElement>;
@@ -54,7 +55,8 @@ export const SearchResultListItem = ({
                 cursor: "pointer",
             }}
         >
-            <CompactSearchResultListItem isSelected={isSelected} searchResultItem={searchResultItem} />
+            {isSelected && <SearchResultListItemSelectedIndicator />}
+            <CompactSearchResultListItem searchResultItem={searchResultItem} />
         </div>
     );
 };

--- a/src/renderer/Core/Search/SearchResultListItem.tsx
+++ b/src/renderer/Core/Search/SearchResultListItem.tsx
@@ -5,13 +5,14 @@ import { CompactSearchResultListItem } from "./CompactSearchResultListItem";
 import { DetailedSearchResultListItem } from "./DetailedSearchResultItem";
 import { elementIsVisible } from "./Helpers";
 import { SearchResultListItemSelectedIndicator } from "./SearchResultListItemSelectedIndicator";
+import type { SearchResultListLayout } from "./SearchResultListLayout";
 
 type SearchResultListItemProps = {
     containerRef: RefObject<HTMLDivElement>;
     isSelected: boolean;
     onClick: () => void;
     onDoubleClick: () => void;
-    layout: "compact" | "detailed";
+    layout: SearchResultListLayout;
     searchResultItem: SearchResultItem;
     scrollBehavior: ScrollBehavior;
 };
@@ -41,7 +42,7 @@ export const SearchResultListItem = ({
         scrollIntoViewIfSelectedAndNotVisible();
     }, [isSelected]);
 
-    const searchResultItemComponent: Record<"compact" | "detailed", () => ReactElement> = {
+    const searchResultItemComponent: Record<SearchResultListLayout, () => ReactElement> = {
         compact: () => <CompactSearchResultListItem searchResultItem={searchResultItem} />,
         detailed: () => <DetailedSearchResultListItem searchResultItem={searchResultItem} />,
     };

--- a/src/renderer/Core/Search/SearchResultListItem.tsx
+++ b/src/renderer/Core/Search/SearchResultListItem.tsx
@@ -1,7 +1,8 @@
 import type { SearchResultItem } from "@common/Core";
 import { tokens } from "@fluentui/react-components";
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { useEffect, useRef, useState, type ReactElement, type RefObject } from "react";
 import { CompactSearchResultListItem } from "./CompactSearchResultListItem";
+import { DetailedSearchResultListItem } from "./DetailedSearchResultItem";
 import { elementIsVisible } from "./Helpers";
 import { SearchResultListItemSelectedIndicator } from "./SearchResultListItemSelectedIndicator";
 
@@ -10,6 +11,7 @@ type SearchResultListItemProps = {
     isSelected: boolean;
     onClick: () => void;
     onDoubleClick: () => void;
+    layout: "compact" | "detailed";
     searchResultItem: SearchResultItem;
     scrollBehavior: ScrollBehavior;
 };
@@ -21,6 +23,7 @@ export const SearchResultListItem = ({
     onDoubleClick,
     searchResultItem,
     scrollBehavior,
+    layout,
 }: SearchResultListItemProps) => {
     const ref = useRef<HTMLDivElement>(null);
     const [isHovered, setIsHovered] = useState<boolean>(false);
@@ -37,6 +40,11 @@ export const SearchResultListItem = ({
     useEffect(() => {
         scrollIntoViewIfSelectedAndNotVisible();
     }, [isSelected]);
+
+    const searchResultItemComponent: Record<"compact" | "detailed", () => ReactElement> = {
+        compact: () => <CompactSearchResultListItem searchResultItem={searchResultItem} />,
+        detailed: () => <DetailedSearchResultListItem searchResultItem={searchResultItem} />,
+    };
 
     return (
         <div
@@ -56,7 +64,8 @@ export const SearchResultListItem = ({
             }}
         >
             {isSelected && <SearchResultListItemSelectedIndicator />}
-            <CompactSearchResultListItem searchResultItem={searchResultItem} />
+
+            {searchResultItemComponent[layout]()}
         </div>
     );
 };

--- a/src/renderer/Core/Search/SearchResultListItemSelectedIndicator.tsx
+++ b/src/renderer/Core/Search/SearchResultListItemSelectedIndicator.tsx
@@ -1,0 +1,18 @@
+import { tokens } from "@fluentui/react-components";
+
+export const SearchResultListItemSelectedIndicator = () => {
+    return (
+        <div
+            style={{
+                position: "absolute",
+                left: 0,
+                top: "50%",
+                backgroundColor: tokens.colorBrandForeground1,
+                height: "45%",
+                width: 3,
+                transform: "translateY(-50%)",
+                borderRadius: tokens.borderRadiusLarge,
+            }}
+        ></div>
+    );
+};

--- a/src/renderer/Core/Search/SearchResultListLayout.ts
+++ b/src/renderer/Core/Search/SearchResultListLayout.ts
@@ -1,0 +1,1 @@
+export type SearchResultListLayout = "compact" | "detailed";


### PR DESCRIPTION
This PR introduces a new "layout" option on the `SearchResultList` component. Currently available are "compact" (looks like the current search results) and "detailed" which has 2 lines of text per search result item. The first line represents the search result name and on the second line we can in the future show more details. Here is how it looks:

|compact|detailed|
|---|---|
|![image](https://github.com/user-attachments/assets/430905f4-1b87-4316-bdea-b37b520b9967)|![image](https://github.com/user-attachments/assets/a68b786d-ebf3-480f-ad24-a5ab0a2bd0b8)|


