### PR TITLE
VSCode: add setting to show path

### DIFF
--- a/src/main/Extensions/VSCode/Settings.ts
+++ b/src/main/Extensions/VSCode/Settings.ts
@@ -1,4 +1,5 @@
 export type Settings = {
     prefix: string;
     command: string;
+    showPath: boolean;
 };

--- a/src/renderer/Extensions/VSCode/VSCodeSettings.tsx
+++ b/src/renderer/Extensions/VSCode/VSCodeSettings.tsx
@@ -2,7 +2,7 @@ import { useExtensionSetting } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { SettingGroup } from "@Core/Settings/SettingGroup";
 import { SettingGroupList } from "@Core/Settings/SettingGroupList";
-import { Input, Tooltip } from "@fluentui/react-components";
+import { Input, Switch, Tooltip } from "@fluentui/react-components";
 import { Info16Regular } from "@fluentui/react-icons";
 import { useTranslation } from "react-i18next";
 
@@ -19,6 +19,11 @@ export const VSCodeSettings = () => {
     const { value: command, updateValue: setCommand } = useExtensionSetting<string>({
         extensionId,
         key: "command",
+    });
+
+    const { value: showPath, updateValue: setShowPath } = useExtensionSetting<boolean>({
+        extensionId,
+        key: "showPath",
     });
 
     return (
@@ -38,6 +43,10 @@ export const VSCodeSettings = () => {
                             <Input value={command} onChange={(_, { value }) => setCommand(value)} />
                         </>
                     }
+                />
+                <Setting
+                    label={t("showPath")}
+                    control={<Switch checked={showPath} onChange={(_, { checked }) => setShowPath(checked)} />}
                 />
             </SettingGroup>
         </SettingGroupList>


### PR DESCRIPTION
This closes #1336 by adding a setting to show the path in the search results list.

![grafik](https://github.com/user-attachments/assets/c83c5ccd-209c-4368-bf53-3af16330e1fa)

![grafik](https://github.com/user-attachments/assets/c0c1b32b-19bb-4ea1-a0c7-4787d973541f)

Additional improvements:
- Changing settings no longer requires re-indexing since the settings are now applied in `getInstantSearchResultItems()`
- Improved commandTooltip translation