### PR TITLE
fix: remove not working drag and drop for linux applications

### DIFF
--- a/src/main/Extensions/ApplicationSearch/Linux/LinuxApplication.ts
+++ b/src/main/Extensions/ApplicationSearch/Linux/LinuxApplication.ts
@@ -19,7 +19,6 @@ export class LinuxApplication implements Application {
                 namespace: "extension[ApplicationSearch]",
             },
             details: this.filePath,
-            dragAndDrop: { filePath: this.filePath },
             id: this.getId(),
             name: this.name,
             image: this.image,


### PR DESCRIPTION
This PR removes the not working drag&drop for Linux applications. I think it doesn't make sense to have it until we know how to make it actually work.