### PR TITLE
Application Search: check folder exists on Windows

### DIFF
--- a/src/main/Extensions/ApplicationSearch/ApplicationSearchModule.ts
+++ b/src/main/Extensions/ApplicationSearch/ApplicationSearchModule.ts
@@ -32,6 +32,7 @@ export class ApplicationSearchModule implements ExtensionModule {
                 new WindowsApplicationRepository(
                     moduleRegistry.get("PowershellUtility"),
                     settings,
+                    moduleRegistry.get("FileSystemUtility"),
                     moduleRegistry.get("FileImageGenerator"),
                     moduleRegistry.get("Logger"),
                     moduleRegistry.get("AssetPathResolver"),


### PR DESCRIPTION
Since v9 when a folder does not exist on Windows it fails to scan other folders while in v8 it was just a warning and skipped invalid paths. This might happen when for example you're using a USB drive that might not be plugged in. I think we should keep the same behavior. This is also consistent with behavior on Linux.