### PR TITLE
refactor: move excluded items to separate settings page

### DIFF
--- a/src/renderer/Core/I18n/getCoreResources.ts
+++ b/src/renderer/Core/I18n/getCoreResources.ts
@@ -602,10 +602,6 @@ export const getCoreResources = (): { namespace: string; resources: Resources<Tr
                     rescanIntervalInSeconds: "Rescan interval (in seconds)",
                     rescanIntervalTooShort: "Rescan interval must be at least 10 seconds",
                     rescanIntervalResetToDefault: "Reset to default",
-                    excludedItems: "Excluded items",
-                    noExcludedItems: "There are no excluded items",
-                    removeExcludedItem: "Remove item",
-                    keyboardShortcutForManualRescan: "Keyboard shortcut for manual rescan",
                 },
                 "de-CH": {
                     title: "Suchmaschine",
@@ -616,10 +612,6 @@ export const getCoreResources = (): { namespace: string; resources: Resources<Tr
                     rescanIntervalInSeconds: "Neuscan-Intervall (in Sekunden)",
                     rescanIntervalTooShort: "Neuscan-Intervall muss mindestens 10 Sekunden betragen",
                     rescanIntervalResetToDefault: "Auf Standardwert zurücksetzen",
-                    excludedItems: "Ausgeschlossene Elemente",
-                    noExcludedItems: "Es gibt keine ausgeschlossene Elemente",
-                    removeExcludedItem: "Element entfernen",
-                    keyboardShortcutForManualRescan: "Tastatur-Shortcut für manuelles neu Scannen",
                 },
                 "ja-JP": {
                     title: "検索エンジン",
@@ -630,10 +622,6 @@ export const getCoreResources = (): { namespace: string; resources: Resources<Tr
                     rescanIntervalInSeconds: "再読み込み間隔 (秒)",
                     rescanIntervalTooShort: "再読み込み間隔は10秒以上にしてください",
                     rescanIntervalResetToDefault: "初期値にリセット",
-                    excludedItems: "除外対象",
-                    noExcludedItems: "除外対象はありません",
-                    removeExcludedItem: "削除",
-                    keyboardShortcutForManualRescan: "再読み込みのキーボードショートカット",
                 },
                 "ko-KR": {
                     title: "검색 엔진",
@@ -644,6 +632,35 @@ export const getCoreResources = (): { namespace: string; resources: Resources<Tr
                     rescanIntervalInSeconds: "재탐색 간격 (초)",
                     rescanIntervalTooShort: "재탐색 간격은 최소 10초 이상이어야 합니다",
                     rescanIntervalResetToDefault: "기본값으로 재설정",
+                },
+            },
+        },
+        {
+            namespace: "settingsExcludedItems",
+            resources: {
+                "en-US": {
+                    title: "Excluded Items",
+                    excludedItems: "Excluded items",
+                    noExcludedItems: "There are no excluded items",
+                    removeExcludedItem: "Remove item",
+                    keyboardShortcutForManualRescan: "Keyboard shortcut for manual rescan",
+                },
+                "de-CH": {
+                    title: "Ausgeschlossene Elemente",
+                    excludedItems: "Ausgeschlossene Elemente",
+                    noExcludedItems: "Es gibt keine ausgeschlossene Elemente",
+                    removeExcludedItem: "Element entfernen",
+                    keyboardShortcutForManualRescan: "Tastatur-Shortcut für manuelles neu Scannen",
+                },
+                "ja-JP": {
+                    title: "除外対象",
+                    excludedItems: "除外対象",
+                    noExcludedItems: "除外対象はありません",
+                    removeExcludedItem: "削除",
+                    keyboardShortcutForManualRescan: "再読み込みのキーボードショートカット",
+                },
+                "ko-KR": {
+                    title: "제외된 항목",
                     excludedItems: "제외된 항목",
                     noExcludedItems: "제외된 항목이 없습니다",
                     removeExcludedItem: "제거",

--- a/src/renderer/Core/Settings/Pages/SearchEngine/ExcludedItems.tsx
+++ b/src/renderer/Core/Settings/Pages/SearchEngine/ExcludedItems.tsx
@@ -1,4 +1,6 @@
 import { useSearchResultItems } from "@Core/Hooks";
+import { SettingGroup } from "@Core/Settings/SettingGroup";
+import { SettingGroupList } from "@Core/Settings/SettingGroupList";
 import { ThemeContext } from "@Core/Theme";
 import { getImageUrl } from "@Core/getImageUrl";
 import { Badge, Button, Input, Text, Tooltip } from "@fluentui/react-components";
@@ -8,7 +10,7 @@ import { useTranslation } from "react-i18next";
 
 export const ExcludedItems = () => {
     const { shouldUseDarkColors } = useContext(ThemeContext);
-    const { t } = useTranslation("settingsSearchEngine");
+    const { t } = useTranslation("settingsExcludedItems");
     const { searchResultItems } = useSearchResultItems();
 
     const [excludedIds, setExcludedIds] = useState<string[]>(window.ContextBridge.getExcludedSearchResultItemIds());
@@ -21,39 +23,43 @@ export const ExcludedItems = () => {
     const excludedSearchResultItems = searchResultItems.filter((f) => excludedIds.includes(f.id));
 
     return (
-        <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
-            {excludedSearchResultItems.length ? null : <Text italic>{t("noExcludedItems")}</Text>}
-            {excludedSearchResultItems.map(({ id, name, image, description }) => (
-                <Input
-                    key={`excludedItem-${id}`}
-                    readOnly
-                    value={name}
-                    contentBefore={
-                        <img
-                            alt="Excluded search result item image"
-                            style={{ width: 16, height: 16 }}
-                            src={getImageUrl({ image, shouldUseDarkColors })}
+        <SettingGroupList>
+            <SettingGroup title={t("excludedItems")}>
+                <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+                    {excludedSearchResultItems.length ? null : <Text italic>{t("noExcludedItems")}</Text>}
+                    {excludedSearchResultItems.map(({ id, name, image, description }) => (
+                        <Input
+                            key={`excludedItem-${id}`}
+                            readOnly
+                            value={name}
+                            contentBefore={
+                                <img
+                                    alt="Excluded search result item image"
+                                    style={{ width: 16, height: 16 }}
+                                    src={getImageUrl({ image, shouldUseDarkColors })}
+                                />
+                            }
+                            contentAfter={
+                                <div>
+                                    <Badge size="small" appearance="ghost">
+                                        {description}
+                                    </Badge>
+                                    <Button
+                                        size="small"
+                                        appearance="subtle"
+                                        onClick={() => removeExcludedSearchResultItem(id)}
+                                        icon={
+                                            <Tooltip content={t("removeExcludedItem")} relationship="label" withArrow>
+                                                <DismissRegular fontSize={14} />
+                                            </Tooltip>
+                                        }
+                                    />
+                                </div>
+                            }
                         />
-                    }
-                    contentAfter={
-                        <div>
-                            <Badge size="small" appearance="ghost">
-                                {description}
-                            </Badge>
-                            <Button
-                                size="small"
-                                appearance="subtle"
-                                onClick={() => removeExcludedSearchResultItem(id)}
-                                icon={
-                                    <Tooltip content={t("removeExcludedItem")} relationship="label" withArrow>
-                                        <DismissRegular fontSize={14} />
-                                    </Tooltip>
-                                }
-                            />
-                        </div>
-                    }
-                />
-            ))}
-        </div>
+                    ))}
+                </div>
+            </SettingGroup>
+        </SettingGroupList>
     );
 };

--- a/src/renderer/Core/Settings/Pages/SearchEngine/SearchEngine.tsx
+++ b/src/renderer/Core/Settings/Pages/SearchEngine/SearchEngine.tsx
@@ -1,9 +1,7 @@
 import { useSetting } from "@Core/Hooks";
 import { SettingGroup } from "@Core/Settings/SettingGroup";
 import { SettingGroupList } from "@Core/Settings/SettingGroupList";
-import { useTranslation } from "react-i18next";
 import { AutomaticRescan } from "./AutomaticRescan";
-import { ExcludedItems } from "./ExcludedItems";
 import { Fuzziness } from "./Fuzziness";
 import { ManualRescanKeyboardShortcut } from "./ManualRescanKeyboardShortcut";
 import { MaxResultLength } from "./MaxResultLength";
@@ -11,8 +9,6 @@ import { RescanInterval } from "./RescanInterval";
 import { SearchEngineId } from "./SearchEngineId";
 
 export const SearchEngine = () => {
-    const { t } = useTranslation("settingsSearchEngine");
-
     const { value: automaticRescanEnabled, updateValue: setAutomaticRescanEnabled } = useSetting({
         key: "searchEngine.automaticRescan",
         defaultValue: true,
@@ -30,9 +26,6 @@ export const SearchEngine = () => {
                 <ManualRescanKeyboardShortcut />
                 <Fuzziness />
                 <MaxResultLength />
-            </SettingGroup>
-            <SettingGroup title={t("excludedItems")}>
-                <ExcludedItems />
             </SettingGroup>
         </SettingGroupList>
     );

--- a/src/renderer/Core/Settings/Pages/index.tsx
+++ b/src/renderer/Core/Settings/Pages/index.tsx
@@ -1,6 +1,7 @@
 import {
     AppsAddIn20Regular,
     Bug20Regular,
+    EyeOffRegular,
     Info20Regular,
     Keyboard20Regular,
     PaintBrush20Regular,
@@ -18,6 +19,7 @@ import { Favorites } from "./Favorites";
 import { General } from "./General";
 import { KeyboardAndMouse } from "./KeyboardAndMouse";
 import { SearchEngine } from "./SearchEngine";
+import { ExcludedItems } from "./SearchEngine/ExcludedItems";
 import { Window } from "./Window";
 
 export type SettingsPage = {
@@ -70,6 +72,13 @@ export const settingsPages: SettingsPage[] = [
         absolutePath: "/favorites",
         element: <Favorites />,
         icon: <Star20Regular />,
+    },
+    {
+        translation: { key: "title", namespace: "settingsExcludedItems" },
+        relativePath: "excluded-items",
+        absolutePath: "/excluded-items",
+        element: <ExcludedItems />,
+        icon: <EyeOffRegular />,
     },
     {
         translation: { key: "title", namespace: "settingsExtensions" },

--- a/src/renderer/Core/Settings/Pages/index.tsx
+++ b/src/renderer/Core/Settings/Pages/index.tsx
@@ -1,7 +1,7 @@
 import {
     AppsAddIn20Regular,
     Bug20Regular,
-    EyeOffRegular,
+    EyeOff20Regular,
     Info20Regular,
     Keyboard20Regular,
     PaintBrush20Regular,
@@ -78,7 +78,7 @@ export const settingsPages: SettingsPage[] = [
         relativePath: "excluded-items",
         absolutePath: "/excluded-items",
         element: <ExcludedItems />,
-        icon: <EyeOffRegular />,
+        icon: <EyeOff20Regular />,
     },
     {
         translation: { key: "title", namespace: "settingsExtensions" },


### PR DESCRIPTION
This PR moves the excluded items to a separate settings page as suggested in #1326.