### PR TITLE
refactor(ConfirmationDialog): use invokeAction from controller

### DIFF
--- a/src/renderer/Core/I18n/getCoreResources.ts
+++ b/src/renderer/Core/I18n/getCoreResources.ts
@@ -77,6 +77,35 @@ export const getCoreResources = (): { namespace: string; resources: Resources<Tr
             },
         },
         {
+            namespace: "confirmationDialog",
+            resources: {
+                "en-US": {
+                    title: "Are you sure?",
+                    description: `You are about to invoke "{{actionDescription}}"`,
+                    confirm: "Yes",
+                    cancel: "No",
+                },
+                "de-CH": {
+                    title: "Bist du sicher?",
+                    description: `Du bist dabei "{{actionDescription}}" auszuführen`,
+                    confirm: "Ja",
+                    cancel: "Nein",
+                },
+                "ja-JP": {
+                    title: "本当に実行しますか？",
+                    description: "本当に{{actionDescription}}を実行しますか？",
+                    confirm: "はい",
+                    cancel: "いいえ",
+                },
+                "ko-KR": {
+                    title: "정말로 실행하시겠습니까?",
+                    description: "정말로 {{actionDescription}}을 실행하시겠습니까?",
+                    confirm: "예",
+                    cancel: "아니요",
+                },
+            },
+        },
+        {
             namespace: "settingsGeneral",
             resources: {
                 "en-US": {

--- a/src/renderer/Core/Search/ConfirmationDialog.tsx
+++ b/src/renderer/Core/Search/ConfirmationDialog.tsx
@@ -8,7 +8,7 @@ import {
     DialogSurface,
     DialogTitle,
 } from "@fluentui/react-components";
-import { t } from "i18next";
+import { useTranslation } from "react-i18next";
 
 type ConfirmationDialogProps = {
     action?: SearchResultItemAction;
@@ -17,10 +17,18 @@ type ConfirmationDialogProps = {
 };
 
 export const ConfirmationDialog = ({ action, closeDialog, confirm }: ConfirmationDialogProps) => {
+    const { t } = useTranslation("confirmationDialog");
+
+    const actionDescription = action?.descriptionTranslation
+        ? t(action?.descriptionTranslation.key, { ns: action?.descriptionTranslation.namespace })
+        : action?.description;
+
     return (
         <Dialog
             open={action !== undefined}
-            onOpenChange={(_, { open }) => {
+            onOpenChange={(event, { open }) => {
+                event.stopPropagation();
+
                 if (open === false) {
                     closeDialog();
                 }
@@ -28,17 +36,11 @@ export const ConfirmationDialog = ({ action, closeDialog, confirm }: Confirmatio
         >
             <DialogSurface>
                 <DialogBody>
-                    <DialogTitle>Are you sure?</DialogTitle>
-                    <DialogContent>
-                        You are about to "
-                        {action?.descriptionTranslation
-                            ? t(action?.descriptionTranslation.key, { ns: action?.descriptionTranslation.namespace })
-                            : action?.description}
-                        "
-                    </DialogContent>
+                    <DialogTitle>{t("title")}</DialogTitle>
+                    <DialogContent>{t("description", { actionDescription })}</DialogContent>
                     <DialogActions>
                         <Button onClick={closeDialog} appearance="secondary">
-                            No
+                            {t("cancel")}
                         </Button>
                         <Button
                             onClick={() => {
@@ -47,7 +49,7 @@ export const ConfirmationDialog = ({ action, closeDialog, confirm }: Confirmatio
                             }}
                             appearance="primary"
                         >
-                            Yes
+                            {t("confirm")}
                         </Button>
                     </DialogActions>
                 </DialogBody>

--- a/src/renderer/Core/Search/ConfirmationDialog.tsx
+++ b/src/renderer/Core/Search/ConfirmationDialog.tsx
@@ -13,16 +13,10 @@ import { t } from "i18next";
 type ConfirmationDialogProps = {
     action?: SearchResultItemAction;
     closeDialog: () => void;
+    confirm: () => void;
 };
 
-export const ConfirmationDialog = ({ action, closeDialog }: ConfirmationDialogProps) => {
-    const invokeAction = async () => {
-        if (action) {
-            closeDialog();
-            await window.ContextBridge.invokeAction(action);
-        }
-    };
-
+export const ConfirmationDialog = ({ action, closeDialog, confirm }: ConfirmationDialogProps) => {
     return (
         <Dialog
             open={action !== undefined}
@@ -46,7 +40,13 @@ export const ConfirmationDialog = ({ action, closeDialog }: ConfirmationDialogPr
                         <Button onClick={closeDialog} appearance="secondary">
                             No
                         </Button>
-                        <Button onClick={invokeAction} appearance="primary">
+                        <Button
+                            onClick={() => {
+                                confirm();
+                                closeDialog();
+                            }}
+                            appearance="primary"
+                        >
                             Yes
                         </Button>
                     </DialogActions>

--- a/src/renderer/Core/Search/Search.tsx
+++ b/src/renderer/Core/Search/Search.tsx
@@ -104,7 +104,10 @@ export const Search = ({
                             searchHistory.add(searchTerm.value);
 
                             if (searchResultItemAction !== undefined) {
-                                invokeAction(searchResultItemAction);
+                                invokeAction({
+                                    action: searchResultItemAction,
+                                    confirmed: !searchResultItemAction.requiresConfirmation,
+                                });
                             }
                         },
                     };
@@ -133,9 +136,12 @@ export const Search = ({
 
     const clickHandlers: Record<string, (s: SearchResultItem) => void> = {
         selectSearchResultItem: (s) => selectedItemId.set(s.id),
-        invokeSearchResultItem: (s) => {
+        invokeSearchResultItem: ({ defaultAction }) => {
             searchHistory.add(searchTerm.value);
-            invokeAction(s.defaultAction);
+            invokeAction({
+                action: defaultAction,
+                confirmed: !defaultAction.requiresConfirmation,
+            });
         },
     };
 
@@ -351,6 +357,11 @@ export const Search = ({
                         <ConfirmationDialog
                             closeDialog={closeConfirmationDialog}
                             action={confirmationDialog.action.value}
+                            confirm={() => {
+                                if (confirmationDialog.action.value) {
+                                    invokeAction({ action: confirmationDialog.action.value, confirmed: true });
+                                }
+                            }}
                         />
                         <div
                             style={{
@@ -437,7 +448,7 @@ export const Search = ({
                         <Divider appearance="subtle" vertical />
                         <ActionsMenu
                             actions={searchResult.currentActions()}
-                            invokeAction={invokeAction}
+                            invokeAction={(action) => invokeAction({ action, confirmed: !action.requiresConfirmation })}
                             additionalActionsButtonRef={additionalActionsButtonRef}
                             open={additionalActionsMenuIsOpen}
                             onOpenChange={toggleAdditionalActionsMenu}

--- a/src/renderer/Core/Search/SearchViewController.ts
+++ b/src/renderer/Core/Search/SearchViewController.ts
@@ -121,11 +121,14 @@ export const useSearchViewController = ({
             return;
         }
 
-        await invokeAction(searchResultItem.defaultAction);
+        await invokeAction({
+            action: searchResultItem.defaultAction,
+            confirmed: !searchResultItem.defaultAction.requiresConfirmation,
+        });
     };
 
-    const invokeAction = async (action: SearchResultItemAction) => {
-        if (!action.requiresConfirmation) {
+    const invokeAction = async ({ action, confirmed }: { action: SearchResultItemAction; confirmed: boolean }) => {
+        if (confirmed) {
             await window.ContextBridge.invokeAction(action);
             return;
         }


### PR DESCRIPTION
This PR refactors the ConfirmationDialog in order to use the `SearchViewController`'s `invokeAction` function. Additionally it adds missing translations and fixes a bug that causes the search window to hide instead of just closing the confirmation dialog when pressing "Esc".