### PR TITLE
feat: add option to clear user input after invoking action

### DIFF
--- a/src/renderer/Core/I18n/getCoreResources.ts
+++ b/src/renderer/Core/I18n/getCoreResources.ts
@@ -163,6 +163,9 @@ export const getCoreResources = (): { namespace: string; resources: Resources<Tr
                     "trayIconShow[Windows]": "Show icon in taskbar",
                     "trayIcon[Linux]": "Tray",
                     "trayIconShow[Linux]": "Show icon in tray",
+                    preserveUserInput: "Preserve user input",
+                    preserveUserInputDescription:
+                        "When disabled the search bar will be cleared after invoking an action",
                 },
                 "de-CH": {
                     title: "Allgemein",
@@ -220,6 +223,9 @@ export const getCoreResources = (): { namespace: string; resources: Resources<Tr
                     "trayIconShow[Windows]": "Symbol im Taskleiste anzeigen",
                     "trayIcon[Linux]": "Infobereich",
                     "trayIconShow[Linux]": "Symbol im Infobereich anzeigen",
+                    preserveUserInput: "Benutzereingabe beibehalten",
+                    preserveUserInputDescription:
+                        "Wenn deaktiviert, wird das Suchfeld nach dem Ausführen einer Aktion gelöscht",
                 },
                 "ja-JP": {
                     title: "一般",

--- a/src/renderer/Core/Search/SearchViewController.ts
+++ b/src/renderer/Core/Search/SearchViewController.ts
@@ -1,4 +1,3 @@
-import { useSetting } from "@Core/Hooks";
 import type { OperatingSystem, SearchResultItem, SearchResultItemAction } from "@common/Core";
 import type { SearchEngineId } from "@common/Core/Search";
 import { useRef, useState } from "react";
@@ -84,11 +83,11 @@ export const useSearchViewController = ({
             : [];
     };
 
-    const { value: fuzziness } = useSetting({ key: "searchEngine.fuzziness", defaultValue: 0.5 });
-    const { value: maxSearchResultItems } = useSetting({ key: "searchEngine.maxResultLength", defaultValue: 50 });
-    const { value: searchEngineId } = useSetting<SearchEngineId>({ key: "searchEngine.id", defaultValue: "fuzzysort" });
-
     const search = (searchTerm: string, selectedItemId?: string) => {
+        const fuzziness = window.ContextBridge.getSettingValue("searchEngine.fuzziness", 0.5);
+        const maxSearchResultItems = window.ContextBridge.getSettingValue("searchEngine.maxResultLength", 50);
+        const searchEngineId = window.ContextBridge.getSettingValue<SearchEngineId>("searchEngine.id", "fuzzysort");
+
         const searchResult = getSearchResult({
             searchEngineId,
             excludedSearchResultItemIds,
@@ -129,6 +128,12 @@ export const useSearchViewController = ({
 
     const invokeAction = async ({ action, confirmed }: { action: SearchResultItemAction; confirmed: boolean }) => {
         if (confirmed) {
+            const preserveUserInput = window.ContextBridge.getSettingValue("general.preserveUserInput", true);
+
+            if (!preserveUserInput) {
+                search("");
+            }
+
             await window.ContextBridge.invokeAction(action);
             return;
         }

--- a/src/renderer/Core/Settings/Pages/General/General.tsx
+++ b/src/renderer/Core/Settings/Pages/General/General.tsx
@@ -7,6 +7,7 @@ import { DockSettings } from "./DockSettings";
 import { HotkeySettings } from "./HotKey";
 import { ImportExport } from "./ImportExport";
 import { Language } from "./Language";
+import { PreserveUserInput } from "./PreserveUserInput";
 import { SearchHistory } from "./SearchHistory";
 import { SetCustomSettingsFilePath } from "./SetCustomSettingsFilePath";
 import { TrayIconSettings } from "./TrayIcon";
@@ -22,6 +23,7 @@ export const General = () => {
                 <Language />
                 <Autostart />
                 {operatingSystem === "macOS" && <DockSettings />}
+                <PreserveUserInput />
             </SettingGroup>
             <TrayIconSettings />
             <HotkeySettings />

--- a/src/renderer/Core/Settings/Pages/General/PreserveUserInput.tsx
+++ b/src/renderer/Core/Settings/Pages/General/PreserveUserInput.tsx
@@ -1,0 +1,18 @@
+import { useSetting } from "@Core/Hooks";
+import { Setting } from "@Core/Settings/Setting";
+import { Switch } from "@fluentui/react-components";
+import { useTranslation } from "react-i18next";
+
+export const PreserveUserInput = () => {
+    const { t } = useTranslation("settingsGeneral");
+
+    const { value, updateValue } = useSetting({ key: "general.preserveUserInput", defaultValue: true });
+
+    return (
+        <Setting
+            label={t("preserveUserInput")}
+            description={t("preserveUserInputDescription")}
+            control={<Switch checked={value} onChange={(_, { checked }) => updateValue(checked)} />}
+        />
+    );
+};


### PR DESCRIPTION
This PR adds the option "Preserve user input" in the general settings.

<img width="713" alt="image" src="https://github.com/user-attachments/assets/009c742c-2de1-4768-a47d-2d651e9d9cce" />

Fixes #1387