### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/src/main/Core/AppleScriptUtility/AppleScriptUtility.ts
+++ b/src/main/Core/AppleScriptUtility/AppleScriptUtility.ts
@@ -5,6 +5,8 @@ export class AppleScriptUtility implements AppleScriptUtilityInterface {
     public constructor(private readonly commandlineUtility: CommandlineUtility) {}
 
     public async executeAppleScript(appleScript: string): Promise<string> {
-        return await this.commandlineUtility.executeCommand(`osascript -e '${appleScript}'`);
+        const escapedAppleScript = appleScript.replace(/'/g, "'\\''");
+
+        return await this.commandlineUtility.executeCommand(`osascript -e '${escapedAppleScript}'`);
     }
 }

--- a/src/main/Extensions/FileSearch/macOS/MdfindFileSearcher.ts
+++ b/src/main/Extensions/FileSearch/macOS/MdfindFileSearcher.ts
@@ -5,7 +5,8 @@ export class MdfindFileSearcher implements FileSearcher {
     public constructor(private readonly commandlineUtility: CommandlineUtility) {}
 
     public async getFilePathsBySearchTerm(searchTerm: string, maxSearchResultCount: number): Promise<string[]> {
-        const commands = [`mdfind -name "${searchTerm}"`, `head -n ${maxSearchResultCount}`];
+        const escapedSearchTerm = `'${searchTerm.replace(/'/g, "'\\''")}'`;
+        const commands = [`mdfind -name ${escapedSearchTerm}`, `head -n ${maxSearchResultCount}`];
         const stdout = await this.commandlineUtility.executeCommand(commands.join(" | "), { ignoreStdErr: true });
         return stdout.split("\n").filter((filePath) => filePath.trim().length > 0);
     }


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `src/main/Core/AppleScriptUtility/AppleScriptUtility.ts:L7`

The AppleScript text is embedded directly into a shell command using single quotes: `osascript -e '${appleScript}'`. If `appleScript` contains a single quote or shell metacharacters, it can break out of the intended argument and execute arbitrary shell commands.

## Solution

Do not build a shell command string. Invoke `osascript` with an argument array via `spawn`/`execFile` (e.g. `spawn('osascript', ['-e', appleScript])`) or use a robust shell-escaping helper before interpolation.

## Changes

- `src/main/Core/AppleScriptUtility/AppleScriptUtility.ts` (modified)
- `src/main/Extensions/FileSearch/macOS/MdfindFileSearcher.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced