### PR TITLE
VSCode: read recents from shared storage on 1.118+

### DIFF
--- a/docs/Extensions/VSCode/README.md
+++ b/docs/Extensions/VSCode/README.md
@@ -8,10 +8,18 @@ This extension allows you to open recently edited projects and files in vscode.
 
 - Prefix: the prefix that triggers the vscode extension.
 - Command: The command that the extension will invoke to open vscode and pass it the recent item.
+- Show file/folder path: append the path to each search result name.
+- Use legacy recents query: read recents only from the user profile `state.vscdb` (`recently.opened` / `history.recentlyOpenedPathsList`). Leave off to also read local recents from shared storage on VS Code 1.118+.
 
 ## About this extension
 
 Author: [Ethan Conneely](https://github.com/IrishBruse)
+
+Recents are read from VS Code's SQLite state databases:
+
+- **Local folders/files** (VS Code 1.118+): `~/.vscode-shared/sharedStorage/state.vscdb` (`history.recentlyOpenedPathsList`)
+- **Remote workspaces** (GitHub, Codespaces, etc.): `~/.config/Code/User/globalStorage/state.vscdb` (`recently.opened`)
+- **Older VS Code**: user `state.vscdb` (`history.recentlyOpenedPathsList` or `recently.opened`)
 
 Supported operating systems:
 

--- a/docs/Extensions/VSCode/README.md
+++ b/docs/Extensions/VSCode/README.md
@@ -9,17 +9,10 @@ This extension allows you to open recently edited projects and files in vscode.
 - Prefix: the prefix that triggers the vscode extension.
 - Command: The command that the extension will invoke to open vscode and pass it the recent item.
 - Show file/folder path: append the path to each search result name.
-- Use legacy recents query: read recents only from the user profile `state.vscdb` (`recently.opened` / `history.recentlyOpenedPathsList`). Leave off to also read local recents from shared storage on VS Code 1.118+.
 
 ## About this extension
 
 Author: [Ethan Conneely](https://github.com/IrishBruse)
-
-Recents are read from VS Code's SQLite state databases:
-
-- **Local folders/files** (VS Code 1.118+): `~/.vscode-shared/sharedStorage/state.vscdb` (`history.recentlyOpenedPathsList`)
-- **Remote workspaces** (GitHub, Codespaces, etc.): `~/.config/Code/User/globalStorage/state.vscdb` (`recently.opened`)
-- **Older VS Code**: user `state.vscdb` (`history.recentlyOpenedPathsList` or `recently.opened`)
 
 Supported operating systems:
 

--- a/src/main/Extensions/VSCode/Settings.ts
+++ b/src/main/Extensions/VSCode/Settings.ts
@@ -2,4 +2,5 @@ export type Settings = {
     prefix: string;
     command: string;
     showPath: boolean;
+    useLegacyRecentsQuery: boolean;
 };

--- a/src/main/Extensions/VSCode/Settings.ts
+++ b/src/main/Extensions/VSCode/Settings.ts
@@ -2,5 +2,4 @@ export type Settings = {
     prefix: string;
     command: string;
     showPath: boolean;
-    useLegacyRecentsQuery: boolean;
 };

--- a/src/main/Extensions/VSCode/VSCodeExtension.test.ts
+++ b/src/main/Extensions/VSCode/VSCodeExtension.test.ts
@@ -4,10 +4,7 @@ import { getRecentUri, isPath, mergeRecents } from "./VSCodeExtension";
 describe(mergeRecents, () => {
     it("should merge lists in order and deduplicate by uri", () => {
         const local = [{ folderUri: "file:///home/user/project-a" }, { folderUri: "file:///home/user/project-b" }];
-        const remote = [
-            { folderUri: "vscode-vfs://github/org/repo" },
-            { folderUri: "file:///home/user/project-a" },
-        ];
+        const remote = [{ folderUri: "vscode-vfs://github/org/repo" }, { folderUri: "file:///home/user/project-a" }];
 
         expect(mergeRecents(local, remote)).toEqual([
             { folderUri: "file:///home/user/project-a" },

--- a/src/main/Extensions/VSCode/VSCodeExtension.test.ts
+++ b/src/main/Extensions/VSCode/VSCodeExtension.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from "vitest";
-import { isPath } from "./VSCodeExtension";
+import { getRecentUri, isPath, mergeRecents } from "./VSCodeExtension";
+
+describe(mergeRecents, () => {
+    it("should merge lists in order and deduplicate by uri", () => {
+        const local = [{ folderUri: "file:///home/user/project-a" }, { folderUri: "file:///home/user/project-b" }];
+        const remote = [
+            { folderUri: "vscode-vfs://github/org/repo" },
+            { folderUri: "file:///home/user/project-a" },
+        ];
+
+        expect(mergeRecents(local, remote)).toEqual([
+            { folderUri: "file:///home/user/project-a" },
+            { folderUri: "file:///home/user/project-b" },
+            { folderUri: "vscode-vfs://github/org/repo" },
+        ]);
+    });
+
+    it("should support workspace config paths", () => {
+        const entries = [{ workspace: { id: "abc", configPath: "file:///home/user/workspace.code-workspace" } }];
+
+        expect(getRecentUri(entries[0])).toBe("file:///home/user/workspace.code-workspace");
+        expect(mergeRecents(entries)).toEqual(entries);
+    });
+});
 
 describe(isPath, () => {
     it("should return true for absolute unix style absolute paths", () => {

--- a/src/main/Extensions/VSCode/VSCodeExtension.ts
+++ b/src/main/Extensions/VSCode/VSCodeExtension.ts
@@ -95,13 +95,6 @@ export class VSCodeExtension implements Extension {
     private getRecentsRaw(): VSCodeRecentRaw[] {
         const userDatabasePath = this.stateDatabasePaths[this.operatingSystem];
 
-        if (this.useLegacyRecentsQuery()) {
-            return mergeRecents(
-                this.getRecentsFromDatabase(userDatabasePath, "recently.opened"),
-                this.getRecentsFromDatabase(userDatabasePath, "history.recentlyOpenedPathsList"),
-            );
-        }
-
         return mergeRecents(
             this.getRecentsFromDatabase(
                 this.sharedStateDatabasePaths[this.operatingSystem],
@@ -109,13 +102,6 @@ export class VSCodeExtension implements Extension {
             ),
             this.getRecentsFromDatabase(userDatabasePath, "recently.opened"),
             this.getRecentsFromDatabase(userDatabasePath, "history.recentlyOpenedPathsList"),
-        );
-    }
-
-    private useLegacyRecentsQuery(): boolean {
-        return this.settingsManager.getValue<boolean>(
-            `extension[${this.id}].useLegacyRecentsQuery`,
-            this.getSettingDefaultValue("useLegacyRecentsQuery"),
         );
     }
 
@@ -227,7 +213,6 @@ export class VSCodeExtension implements Extension {
             prefix: "vscode",
             command: "code %s",
             showPath: false,
-            useLegacyRecentsQuery: false,
         };
 
         if (this.operatingSystem === "macOS") {
@@ -264,8 +249,6 @@ export class VSCodeExtension implements Extension {
                 commandTooltip:
                     "Use %s where the selected file/project should be inserted. It uses the --file-uri or --folder-uri switch",
                 showPath: "Show file/folder path",
-                useLegacyRecentsQuery: "Use legacy recents query",
-                useLegacyRecentsQueryDescription: "Enable if on VS Code <1.118.",
             },
             "ja-JP": {
                 extensionName: "Visual Studio Code",

--- a/src/main/Extensions/VSCode/VSCodeExtension.ts
+++ b/src/main/Extensions/VSCode/VSCodeExtension.ts
@@ -112,9 +112,12 @@ export class VSCodeExtension implements Extension {
 
         try {
             const raw = new Database(databasePath, { readonly: true })
-                .prepare("SELECT json_extract(value, '$.entries') as entries FROM ItemTable WHERE key = ?")
+                .prepare<
+                    string,
+                    string | null
+                >("SELECT json_extract(value, '$.entries') as entries FROM ItemTable WHERE key = ?")
                 .pluck()
-                .get(key) as string | null;
+                .get(key);
 
             if (!raw) {
                 return [];

--- a/src/main/Extensions/VSCode/VSCodeExtension.ts
+++ b/src/main/Extensions/VSCode/VSCodeExtension.ts
@@ -57,6 +57,13 @@ export class VSCodeExtension implements Extension {
         Linux: process.env.HOME + "/.config/Code/User/globalStorage/state.vscdb",
     };
 
+    // VS Code 1.118+ stores local recents in application-shared storage.
+    private readonly sharedStateDatabasePaths = {
+        Windows: process.env.USERPROFILE + "/.vscode-shared/sharedStorage/state.vscdb",
+        macOS: process.env.HOME + "/.vscode-shared/sharedStorage/state.vscdb",
+        Linux: process.env.HOME + "/.vscode-shared/sharedStorage/state.vscdb",
+    };
+
     private recents: VSCodeRecent[] = [];
 
     public constructor(
@@ -86,16 +93,52 @@ export class VSCodeExtension implements Extension {
     }
 
     private getRecentsRaw(): VSCodeRecentRaw[] {
-        const databasePath = this.stateDatabasePaths[this.operatingSystem];
+        const userDatabasePath = this.stateDatabasePaths[this.operatingSystem];
 
-        return JSON.parse(
-            new Database(databasePath, {})
-                .prepare(
-                    "SELECT json_extract(value, '$.entries') as entries FROM ItemTable WHERE key = 'history.recentlyOpenedPathsList'",
-                )
-                .pluck()
-                .get() as string,
+        if (this.useLegacyRecentsQuery()) {
+            return mergeRecents(
+                this.getRecentsFromDatabase(userDatabasePath, "recently.opened"),
+                this.getRecentsFromDatabase(userDatabasePath, "history.recentlyOpenedPathsList"),
+            );
+        }
+
+        return mergeRecents(
+            this.getRecentsFromDatabase(
+                this.sharedStateDatabasePaths[this.operatingSystem],
+                "history.recentlyOpenedPathsList",
+            ),
+            this.getRecentsFromDatabase(userDatabasePath, "recently.opened"),
+            this.getRecentsFromDatabase(userDatabasePath, "history.recentlyOpenedPathsList"),
         );
+    }
+
+    private useLegacyRecentsQuery(): boolean {
+        return this.settingsManager.getValue<boolean>(
+            `extension[${this.id}].useLegacyRecentsQuery`,
+            this.getSettingDefaultValue("useLegacyRecentsQuery"),
+        );
+    }
+
+    private getRecentsFromDatabase(databasePath: string, key: string): VSCodeRecentRaw[] {
+        if (!this.fileSystemUtility.existsSync(databasePath)) {
+            return [];
+        }
+
+        try {
+            const raw = new Database(databasePath, { readonly: true })
+                .prepare("SELECT json_extract(value, '$.entries') as entries FROM ItemTable WHERE key = ?")
+                .pluck()
+                .get(key) as string | null;
+
+            if (!raw) {
+                return [];
+            }
+
+            return JSON.parse(raw);
+        } catch (error) {
+            this.logger.error(`${this.id}: failed to read recents from ${databasePath} (${key}): ${error}`);
+            return [];
+        }
     }
 
     private async getRecent(recentRaw: VSCodeRecentRaw): Promise<VSCodeRecent> {
@@ -184,6 +227,7 @@ export class VSCodeExtension implements Extension {
             prefix: "vscode",
             command: "code %s",
             showPath: false,
+            useLegacyRecentsQuery: false,
         };
 
         if (this.operatingSystem === "macOS") {
@@ -220,6 +264,8 @@ export class VSCodeExtension implements Extension {
                 commandTooltip:
                     "Use %s where the selected file/project should be inserted. It uses the --file-uri or --folder-uri switch",
                 showPath: "Show file/folder path",
+                useLegacyRecentsQuery: "Use legacy recents query",
+                useLegacyRecentsQueryDescription: "Enable if on VS Code <1.118.",
             },
             "ja-JP": {
                 extensionName: "Visual Studio Code",
@@ -352,6 +398,29 @@ export class VSCodeExtension implements Extension {
         );
     }
 }
+
+export const getRecentUri = (recent: VSCodeRecentRaw): string | undefined =>
+    recent.fileUri ?? recent.folderUri ?? recent.workspace?.configPath;
+
+export const mergeRecents = (...lists: VSCodeRecentRaw[][]): VSCodeRecentRaw[] => {
+    const seen = new Set<string>();
+    const result: VSCodeRecentRaw[] = [];
+
+    for (const list of lists) {
+        for (const entry of list) {
+            const uri = getRecentUri(entry);
+
+            if (!uri || seen.has(uri)) {
+                continue;
+            }
+
+            seen.add(uri);
+            result.push(entry);
+        }
+    }
+
+    return result;
+};
 
 export const isPath = (searchTerm: string | null | undefined) => {
     if (!searchTerm) {

--- a/src/renderer/Extensions/VSCode/VSCodeSettings.tsx
+++ b/src/renderer/Extensions/VSCode/VSCodeSettings.tsx
@@ -2,8 +2,7 @@ import { useExtensionSetting } from "@Core/Hooks";
 import { Setting } from "@Core/Settings/Setting";
 import { SettingGroup } from "@Core/Settings/SettingGroup";
 import { SettingGroupList } from "@Core/Settings/SettingGroupList";
-import { Input, Switch, Tooltip } from "@fluentui/react-components";
-import { Info16Regular } from "@fluentui/react-icons";
+import { Input, Switch } from "@fluentui/react-components";
 import { useTranslation } from "react-i18next";
 
 export const VSCodeSettings = () => {
@@ -26,6 +25,11 @@ export const VSCodeSettings = () => {
         key: "showPath",
     });
 
+    const { value: useLegacyRecentsQuery, updateValue: setUseLegacyRecentsQuery } = useExtensionSetting<boolean>({
+        extensionId,
+        key: "useLegacyRecentsQuery",
+    });
+
     return (
         <SettingGroupList>
             <SettingGroup title={t("extensionName")}>
@@ -35,19 +39,24 @@ export const VSCodeSettings = () => {
                 />
                 <Setting
                     label={t("command")}
-                    control={
-                        <>
-                            <Tooltip relationship="description" content={t("commandTooltip")}>
-                                <Info16Regular style={{ marginRight: 20 }} />
-                            </Tooltip>
-                            <Input value={command} onChange={(_, { value }) => setCommand(value)} />
-                        </>
-                    }
+                    description={t("commandTooltip")}
+                    control={<Input value={command} onChange={(_, { value }) => setCommand(value)} />}
                 />
                 <Setting
                     label={t("showPath")}
                     control={
                         <Switch size="small" checked={showPath} onChange={(_, { checked }) => setShowPath(checked)} />
+                    }
+                />
+                <Setting
+                    label={t("useLegacyRecentsQuery")}
+                    description={t("useLegacyRecentsQueryDescription")}
+                    control={
+                        <Switch
+                            size="small"
+                            checked={useLegacyRecentsQuery}
+                            onChange={(_, { checked }) => setUseLegacyRecentsQuery(checked)}
+                        />
                     }
                 />
             </SettingGroup>

--- a/src/renderer/Extensions/VSCode/VSCodeSettings.tsx
+++ b/src/renderer/Extensions/VSCode/VSCodeSettings.tsx
@@ -25,11 +25,6 @@ export const VSCodeSettings = () => {
         key: "showPath",
     });
 
-    const { value: useLegacyRecentsQuery, updateValue: setUseLegacyRecentsQuery } = useExtensionSetting<boolean>({
-        extensionId,
-        key: "useLegacyRecentsQuery",
-    });
-
     return (
         <SettingGroupList>
             <SettingGroup title={t("extensionName")}>
@@ -46,17 +41,6 @@ export const VSCodeSettings = () => {
                     label={t("showPath")}
                     control={
                         <Switch size="small" checked={showPath} onChange={(_, { checked }) => setShowPath(checked)} />
-                    }
-                />
-                <Setting
-                    label={t("useLegacyRecentsQuery")}
-                    description={t("useLegacyRecentsQueryDescription")}
-                    control={
-                        <Switch
-                            size="small"
-                            checked={useLegacyRecentsQuery}
-                            onChange={(_, { checked }) => setUseLegacyRecentsQuery(checked)}
-                        />
                     }
                 />
             </SettingGroup>


### PR DESCRIPTION
### Summary

VS Code 1.118+ moved local recents into shared storage, so ueli was missing recently opened folders and files on newer versions. This PR merges recents from shared and user profile databases in order and deduplicates by URI.

- **Changed:** Recents database reads
- **Changed:** Command setting layout

## VS Code recents

Recents are loaded from shared storage, user profile keys, and legacy history entries, then combined in source order. Duplicate URIs are skipped, including `.code-workspace` config paths. Missing databases and read errors return empty results with logging, so older VS Code installs without shared storage still work.

## Settings

The command field tooltip is shown as a setting description instead of a separate info icon.

## Screenshots

Fixed on newer VS Code versions
<img width="980" height="700" alt="image" src="https://github.com/user-attachments/assets/7281bf67-aae4-45e9-aa13-6d6664065228" />

Settings used to have a i circle
<img width="1571" height="366" alt="image" src="https://github.com/user-attachments/assets/a19438c7-4662-4625-8cae-e9446648cdcc" />
